### PR TITLE
Working Fable import

### DIFF
--- a/client/src/demo.d.ts
+++ b/client/src/demo.d.ts
@@ -1,0 +1,5 @@
+export as namespace Fable
+
+
+export function init(): void;
+

--- a/client/src/demo.fs
+++ b/client/src/demo.fs
@@ -4,7 +4,7 @@ open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Import
 
-let init() =
+let init () =
     let canvas = Browser.document.getElementsByTagName_canvas().[0]
     canvas.width <- 1000.
     canvas.height <- 800.
@@ -15,3 +15,6 @@ let init() =
     ctx.fillRect (10., 10., 55., 50.)
     ctx.fillStyle <- !^"rgba(0, 0, 200, 0.5)"
     ctx.fillRect (30., 30., 55., 50.)
+
+[<ExportDefault>]
+let exports = init

--- a/client/src/foo.js
+++ b/client/src/foo.js
@@ -1,0 +1,3 @@
+export function init2() {
+    console.log("init from javascript");
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,5 +1,11 @@
 //import {init} from 'demo';
-import {init} from 'another';
+// import {init} from 'another';
+
+import { init2 } from "./foo";
+
+import { init } from "./demo";
+
+// import * as Elm from './src/Main'
 
 class Animal {
   constructor(public name) { }
@@ -27,3 +33,7 @@ var tom: Animal = new Horse("Tommy the Palomino")
 
 sam.move()
 tom.move(34)
+
+init2();
+
+init();

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
-    "sourceMap": true
+    "sourceMap": true,
+    "allowJs": true,
+    "esModuleInterop": true,
+    "declaration": true
   }
 }


### PR DESCRIPTION
Disclaimer I just tried to make it work, I didn't make it minimal after I got it working. Sorry too less time (need to leave).

I think the d.ts I created for Fable can be simplified by removing line 1 but I didn't test it because it's working on current state :)

So the idea, is to make the TS compiler happy by explaining him how the Fable file is structure. 

This should also be possible to simplify the `tsconfig.json`

For info: People asked in the past to make Fable generate d.ts or something equivalent and we refused to add it by default into Fable because there is few use case and it's a lot of works.