### PR TITLE
Refactoring to use TypeScript classes

### DIFF
--- a/client/src/languages.ts
+++ b/client/src/languages.ts
@@ -7,11 +7,9 @@ interface Editor {
 }
 
 interface LanguagePlugin {
-  readonly [key: string]: any;
   parse(code:string) : BlockKind;
   editor : Editor;
   language : string;
-  name: string;
 }
 
 export { 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -11,6 +11,34 @@ tsHello();
 // (these are TypeScript interfaces defined in `languages.ts`)
 import * as Langs from './languages';
 
+class MarkdownBlockKind implements Langs.BlockKind {
+  language : string;
+  source : string;
+  constructor(source:string) {
+    this.language = "markdown";
+    this.source = source;
+  }
+}
+
+class MarkdownEditor implements Langs.Editor {
+  create(id:string, block:Langs.BlockKind) {
+    let markdownBlock = <MarkdownBlockKind>block;
+    console.log(markdownBlock.source);
+  }
+}
+
+class MarkdownLanguagePlugin implements Langs.LanguagePlugin {
+  editor : Langs.Editor;
+  language : string;
+  parse(code:string) : Langs.BlockKind {
+    return new MarkdownBlockKind(code);
+  }
+  constructor() {
+    this.editor = new MarkdownEditor();
+    this.language = "markdown";
+  }
+}
+
 // Wrattler will have a number of language plugins for different
 // languages (including R, Python, TheGamma and Markdown). Probably
 // something like this, except that we might need a dictionary or
@@ -18,12 +46,9 @@ import * as Langs from './languages';
 // language quickly):
 
 // fill in language plugins dictionary here eg.
-let languagePluginArray: Langs.LanguagePlugin[] = [];
-languagePluginArray['markdown']={name: "markdown_plugin"};
-languagePluginArray['markdown']['parse'] = function (code:string) {
-  return "brain not working";
-}
-console.log(languagePluginArray['markdown']);
+var languagePlugins : { [language: string]: Langs.LanguagePlugin; } = { };
+languagePlugins["markdown"] = new MarkdownLanguagePlugin();
+console.log(languagePlugins['markdown']);
 
 // A sample document is just an array of records with cells. Each 
 // cell has a language and source code (here, just Markdown):
@@ -42,13 +67,14 @@ let document =
 
 for (let cell of document) {
   var language = cell['language'];
-  if (languagePluginArray[language] == null)
+  if (languagePlugins[language] == null)
     console.log("No language plugins for "+language);
   else 
   {
-    console.log("Language plugin for "+language+" is "+languagePluginArray[language]['name']);
-    let languagePlugin = languagePluginArray[language]; 
-    console.log(languagePlugin['parse']("brain working?"))
+    console.log("Language plugin for " + language + " is " + languagePlugins[language].language);
+    let languagePlugin = languagePlugins[language];
+    let block = languagePlugin.parse("brain working?")
+    languagePlugin.editor.create("tbd", block);
   }
 }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -11,6 +11,11 @@ tsHello();
 // (these are TypeScript interfaces defined in `languages.ts`)
 import * as Langs from './languages';
 
+// We define a new class for `MarkdownBlockKind` because we
+// later need to cast `BlockKind` to `MarkdownBlockKind` so that
+// we can access Markdown-specific properties from editor,
+// type checker, etc. (using <MarkdownBlockKind>block)
+
 class MarkdownBlockKind implements Langs.BlockKind {
   language : string;
   source : string;
@@ -20,22 +25,23 @@ class MarkdownBlockKind implements Langs.BlockKind {
   }
 }
 
-class MarkdownEditor implements Langs.Editor {
-  create(id:string, block:Langs.BlockKind) {
+// For the editor and language plugin, we do not need a dedicated
+// class, because we just need to create some implementation of 
+// an interface - and TypeScript lets us do this using a simple 
+// JavaScript record expression - to this is much simpler than a class.
+
+const markdownEditor : Langs.Editor = {
+  create: (id:string, block:Langs.BlockKind) => {
     let markdownBlock = <MarkdownBlockKind>block;
-    console.log(markdownBlock.source);
+    console.log(markdownBlock.source);    
   }
 }
 
-class MarkdownLanguagePlugin implements Langs.LanguagePlugin {
-  editor : Langs.Editor;
-  language : string;
-  parse(code:string) : Langs.BlockKind {
+const markdownLanguagePlugin : Langs.LanguagePlugin = {
+  language: "markdown",
+  editor: markdownEditor,
+  parse: (code:string) => {
     return new MarkdownBlockKind(code);
-  }
-  constructor() {
-    this.editor = new MarkdownEditor();
-    this.language = "markdown";
   }
 }
 
@@ -47,7 +53,7 @@ class MarkdownLanguagePlugin implements Langs.LanguagePlugin {
 
 // fill in language plugins dictionary here eg.
 var languagePlugins : { [language: string]: Langs.LanguagePlugin; } = { };
-languagePlugins["markdown"] = new MarkdownLanguagePlugin();
+languagePlugins["markdown"] = markdownLanguagePlugin;
 console.log(languagePlugins['markdown']);
 
 // A sample document is just an array of records with cells. Each 


### PR DESCRIPTION
I'm not a TypeScript expert, but I think this is fairly object-oriented part of the code, so this change implements the infrastructure for Markdown parsing using classes.

I created new classes representing Markdown code block (`MarkdownBlockKind`), Markdown language plugin and Markdown editor. These implement the interfaces from `languages.ts`. In addition, the Markdown block stores the text it gets when parsing (just as plain text).

I did some googling and:

```
var languagePlugins : { [language: string]: Langs.LanguagePlugin; } = { };
```

defines a lookup table with key (named `language`) that returns `LanguagePlugin`. This works nicely and TypeScript knows that when we type `languagePlugins["markdown"]` we get back a `LanguagePlugin` object (so you see its members when you type `.`). I also changed the loop to get the editor and call the `create` function (though this does not _create_ the DIV element for the editor yet, it just prints the text passed to the block).

@myyong Please have a look at this and if this looks right to you, merge the PR before doing more work!