### PR TITLE
Integrate VDom with Monaco and use immutable state

### DIFF
--- a/client/src/languages.ts
+++ b/client/src/languages.ts
@@ -1,22 +1,48 @@
 import {VNode} from 'maquette';
 
+/// Each block knows the language that created it
 interface BlockKind {
-  language : string;
+  language : string
 }
 
-interface Editor<TState> {
-  initialize(block:BlockKind) : TState;
-  render(id:number, state:TState) : VNode;
+/// This is passed to the `render` function of `Editor` and it
+/// allows the editor to change its own state when some 
+/// user action happens. The editor just needs to call `trigger`.
+interface EditorContext<TEvent> {
+  trigger(event:TEvent)
+}
+
+/// Every editor needs to remember its own unique ID 
+/// and the block that it is editing.
+interface EditorState {
+  id: number
+  block: BlockKind;
+}
+
+interface Editor<TState extends EditorState, TEvent> {
+  initialize(id:number, block:BlockKind) : TState
+
+  /// The two functions known from the 'Elm' architecture. 
+  /// Update takes a state with an event and produces a new state.
+  update(state:TState, event:TEvent) : TState
+
+  /// Render takes a state and renders VNodes based on the state.
+  /// There are two extra things. The `context` parameter allows it
+  /// to trigger updates when a UI event happens and it can also return
+  /// a post-render handler (to create Monaco editor etc.)
+  render(state:TState, context:EditorContext<TEvent>) : [VNode, () => void]
 }
 
 interface LanguagePlugin {
-  parse(code:string) : BlockKind;
-  editor : Editor<any>;
-  language : string;
+  parse(code:string) : BlockKind
+  editor : Editor<EditorState, any>
+  language : string
 }
 
 export { 
   BlockKind,
   Editor,
+  EditorState,
+  EditorContext,
   LanguagePlugin
 }

--- a/client/src/languages.ts
+++ b/client/src/languages.ts
@@ -26,11 +26,9 @@ interface Editor<TState extends EditorState, TEvent> {
   /// Update takes a state with an event and produces a new state.
   update(state:TState, event:TEvent) : TState
 
-  /// Render takes a state and renders VNodes based on the state.
-  /// There are two extra things. The `context` parameter allows it
-  /// to trigger updates when a UI event happens and it can also return
-  /// a post-render handler (to create Monaco editor etc.)
-  render(state:TState, context:EditorContext<TEvent>) : [VNode, () => void]
+  /// Render takes a state and renders VNodes based on the state. The `context`
+  /// parameter allows it to trigger updates when a UI event happens.
+  render(state:TState, context:EditorContext<TEvent>) : VNode
 }
 
 interface LanguagePlugin {


### PR DESCRIPTION
After some googling, I figured out that we can use `afterCreate` to render monaco editor after maquette does the rendering. See [this StackOverflow answer](https://stackoverflow.com/questions/48156776/how-to-make-other-js-libraries-work-with-maquette-js).

While I was trying to get this to work, I also changed how we manage state so that it is not mutating the states, but instead, creates a new state (as one would in a functional style). I thought this was necessary to get the above to work, but it probably was not (in the end). That said, I still find this nicer.

Each editor is now a nice simple "Elm-style" component that has the following:

 - Its own `TState` type representing state and `TEvent` type representing events
 - Update function that takes state and event and returns a new state
 - Render function that takes a state and renders a VNode. 

The render function gets an object with a `trigger` method that can be used in event handlers in the rendered code to trigger `TEvent` events (which then, in turn, update state).

This makes the individual editors very simple and nice, but there is a bit more bookkeeping - done in the `updateState` function - to update the global `state` after `context.trigger` is called. 