### PR TITLE
Fix compile warnings

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "fable-utils": "1.0.6",
     "html-webpack-plugin": "^3.0.6",
     "html-webpack-polyfill-io-plugin": "^1.0.0",
+    "source-map-support": "0.4.3",
     "jquery": "^3.3.1",
     "monaco-editor": "^0.12.0",
     "style-loader": "^0.21.0",

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,12 +1,12 @@
 // Demos showing how to import files from different languages
 // (we will need this later, but for now, this is just a demo)
-// import { fsHello } from "./demos/fsdemo";
-// import { jsHello } from "./demos/jsdemo";
-// import { tsHello } from "./demos/tsdemo";
+import { fsHello } from "./demos/fsdemo";
+import { jsHello } from "./demos/jsdemo";
+import { tsHello } from "./demos/tsdemo";
 
-// fsHello();
-// jsHello();
-// tsHello();
+fsHello();
+jsHello();
+tsHello();
 
 // ------------------------------------------------------------------------------------------------
 // Imports

--- a/client/tools/webpack.config.dev.js
+++ b/client/tools/webpack.config.dev.js
@@ -33,7 +33,11 @@ module.exports = {
   plugins: common.getPlugins().concat([
       new webpack.HotModuleReplacementPlugin(),
       new webpack.NamedModulesPlugin(),
-      new MonacoWebpackPlugin()
+      new MonacoWebpackPlugin(),
+      new webpack.ContextReplacementPlugin(
+        /monaco-editor(\\|\/)esm(\\|\/)vs(\\|\/)editor(\\|\/)common(\\|\/)services/,
+        __dirname
+      )
   ]),
   resolve: {
     modules: [common.config.nodeModulesDir],

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -13,6 +13,10 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
+"@types/jquery@^3.3.3":
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.4.tgz#f1850fb9a70041a14ace4f81a7ed782db8548317"
+
 "@types/node@^10.0.6":
   version "10.0.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.0.6.tgz#c0bce8e539bf34c1b850c13ff46bead2fecc2e58"
@@ -1090,6 +1094,10 @@ bonjour@^3.5.0:
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
+bootstrap@^4.0.0-alpha.6:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.1.tgz#3aec85000fa619085da8d2e4983dfd67cf2114cb"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -5625,6 +5633,12 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-support@0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.3.tgz#693c8383d4389a4569486987c219744dfc601685"
+  dependencies:
+    source-map "^0.5.3"
 
 source-map-support@^0.4.15:
   version "0.4.18"


### PR DESCRIPTION
This fixes two build warnings we were getting - just following the fixes from these two:

 * https://github.com/evanw/node-source-map-support/issues/155
 * https://github.com/Microsoft/monaco-editor-webpack-plugin/issues/13#issuecomment-390806320