### PR TITLE
Fix async and passing data from Python to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+If you get
+
+> ERROR: for wrattler_wrattler_client_1  Cannot create container for service wrattler_client: b'Drive has not been shared'
+
+You need to share your drives in Docker settings ([Windows](https://blogs.msdn.microsoft.com/stevelasker/2016/06/14/configuring-docker-for-windows-volumes/))
+
+But automatic reload does not work on Windows anyway:
+See https://github.com/docker/compose/issues/4326 and https://github.com/docker/for-win/issues/56

--- a/client/src/languagePlugins/javascript/javascriptPlugin.ts
+++ b/client/src/languagePlugins/javascript/javascriptPlugin.ts
@@ -180,33 +180,32 @@ class JavascriptBlockKind implements Langs.Block {
   export const javascriptLanguagePlugin : Langs.LanguagePlugin = {
     language: "javascript",
     editor: javascriptEditor,
-    evaluate: (node:Graph.Node) => {
+    evaluate: async (node:Graph.Node) => {
       let jsnode = <Graph.JsNode>node
       let value = "yadda";
       let returnArgs = "{";
       let evalCode = "";
 
-      async function getValue() {
-        return new Promise<any>(resolve => {
-          let jsCodeNode = <Graph.JsCodeNode>node
-          for (var e = 0; e < jsCodeNode.exportedVariables.length; e++) {
-            returnArgs= returnArgs.concat(jsCodeNode.exportedVariables[e]+":"+jsCodeNode.exportedVariables[e]+",");
-          }
-          returnArgs = returnArgs.concat("}")
-          let importedVars = "";
-          var argDictionary:{[key: string]: string} = {}
-          for (var i = 0; i < jsCodeNode.antecedents.length; i++) {
-            let imported = <Graph.JsExportNode>jsCodeNode.antecedents[i]
-            argDictionary[imported.variableName] = imported.value;
-            importedVars = importedVars.concat("\nlet "+imported.variableName + " = args[\""+imported.variableName+"\"];");
-          }
-          evalCode = "function f(args) {\n\t "+ importedVars + "\n"+jsCodeNode.source +"\n\t return "+returnArgs+"\n}; f(argDictionary)"
-          console.log(evalCode)
-          value = eval(evalCode);
-          console.log(value);
-          resolve(value);
-        })
+      function getValue() {
+        let jsCodeNode = <Graph.JsCodeNode>node
+        for (var e = 0; e < jsCodeNode.exportedVariables.length; e++) {
+          returnArgs= returnArgs.concat(jsCodeNode.exportedVariables[e]+":"+jsCodeNode.exportedVariables[e]+",");
+        }
+        returnArgs = returnArgs.concat("}")
+        let importedVars = "";
+        var argDictionary:{[key: string]: string} = {}
+        for (var i = 0; i < jsCodeNode.antecedents.length; i++) {
+          let imported = <Graph.JsExportNode>jsCodeNode.antecedents[i]
+          argDictionary[imported.variableName] = imported.value;
+          importedVars = importedVars.concat("\nlet "+imported.variableName + " = args[\""+imported.variableName+"\"];");
+        }
+        evalCode = "function f(args) {\n\t "+ importedVars + "\n"+jsCodeNode.source +"\n\t return "+returnArgs+"\n}; f(argDictionary)"
+        console.log(evalCode)
+        value = eval(evalCode);
+        console.log(value);
+        return value;
       }
+
       switch(jsnode.kind) {
         case 'code': 
           return getValue();
@@ -215,10 +214,7 @@ class JavascriptBlockKind implements Langs.Block {
           let exportNodeName= jsExportNode.variableName;
           value = jsExportNode.code.value[exportNodeName]
           return value
-          // console.log(value);
-          // break;
       }
-      // return value
     },
     parse: (code:string) => {
       console.log(code);

--- a/client/src/languagePlugins/markdown/markdownPlugin.ts
+++ b/client/src/languagePlugins/markdown/markdownPlugin.ts
@@ -162,20 +162,8 @@ class MarkdownBlockKind implements Langs.Block {
 					  }, 10);
 			})
     },
-    evaluate: (node:Graph.Node) => {
-      // let jsnode = <Graph.JsNode>node
-      // switch(jsnode.kind) {
-      //   case 'code': 
-      //     // ..
-      //     jsnode
-      //     break;
-
-      //   case 'export':
-      //     jsnode
-      //     break;
-      //     // ...
-      // }
-      return "yadda"
+    evaluate: async (node:Graph.Node) => {
+      return {};
     },
   }
   

--- a/client/src/languages.ts
+++ b/client/src/languages.ts
@@ -26,7 +26,7 @@ interface LanguagePlugin {
   parse(code:string) : Block
 
   
-  evaluate(node): any
+  evaluate(node): Promise<any>
 
   /**
    * Given a parsed block and a dictionary that tracks variables that are in scope, 

--- a/client/tools/webpack.config.dev.js
+++ b/client/tools/webpack.config.dev.js
@@ -39,12 +39,8 @@ module.exports = {
         __dirname
       ),
       new webpack.DefinePlugin({
-        PRODUCTION: JSON.stringify(true),
-        VERSION: JSON.stringify("5fa3b9"),
-        BROWSER_SUPPORTS_HTML5: true,
-        TWO: JSON.stringify(process.env),
-        APIROOT_TEST: '"https://httpbin.org/"',
-        APIROOT: JSON.stringify(process.env.PYTHONSERVICE_URI)
+        PYTHONSERVICE_URI: JSON.stringify(typeof(process.env.PYTHONSERVICE_URI)=="undefined"?"http://localhost:7101":process.env.PYTHONSERVICE_URI),
+        DATASTORE_URI: JSON.stringify(typeof(process.env.DATASTORE_URI)=="undefined"?"http://localhost:7102":process.env.DATASTORE_URI)
     })
   ]),
   resolve: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
     command: "./entrypoint.sh"
     environment:
      - PYTHONSERVICE_URI=http://localhost:7101
-
+     - DATASTORE_URI=http://localhost:7102
+     
   wrattler_python_service:
     build:
       context: server/python

--- a/server/python/python_service.py
+++ b/server/python/python_service.py
@@ -135,7 +135,7 @@ def evaluate_code(data):
     frame_dict = retrieve_frames(input_frames)
     result = execute_code(rhs, frame_dict)
     frame_name = lhs.strip()
-    data = [{frame_name : result}] ## FIXME frame name vs variable name
+    data = result ## FIXME frame name vs variable name
     wrote_ok = write_frame(data, frame_name, output_hash)
     if wrote_ok:
         return [{"name": frame_name,


### PR DESCRIPTION
This does the following changes:

* I tried fiddling with Docker a bit - automatic reloading does not work on Windows (I added some links to Readme), so the change in `webpack.config.dev.js` makes it easier to run the client locally and everything else in Docker. I also changed the environment variables in docker compose file - but I wonder if specifying the URL as `localhost` is wrong there?

* I made the return type of `evaluate` a promise `Promise<any>`. This showed a few places where we were returning a wrong thing.

* In `main.ts`, the changes to `evaluate` use `async`/`await` to wait until all promises that we start complete (this is still sequential - we could make it parallel, but I'm not sure that would help much).

* In Python service plugin, it should now correctly handle the case when we get multiple different data frames (because the code iterates over all data frames returned by Python and evaluates them).

* For the above, I also changed the actual Python service to only write the raw data into data store (rather than also storing the data frame name) - this is what the prototype did, so we can keep that for now.