### PR TITLE
Improving Python JavaScript interop

### DIFF
--- a/client/src/languagePlugins/python/pythonPlugin.ts
+++ b/client/src/languagePlugins/python/pythonPlugin.ts
@@ -3,9 +3,7 @@ import {h,createProjector,VNode} from 'maquette';
 import * as Langs from '../../languages'; 
 import * as Graph from '../../graph'; 
 import {Md5} from 'ts-md5/dist/md5';
-
-const ts = require('typescript');
-const axios = require('axios');
+import axios from 'axios';
 
 declare var PYTHONSERVICE_URI: string;
 declare var DATASTORE_URI: string;
@@ -46,9 +44,7 @@ class PythonBlockKind implements Langs.Block {
     });
   }
   
-  interface PythonEditEvent { kind:'edit' }
-  interface PythonUpdateEvent { kind:'update', source:string }
-  type PythonEvent = PythonEditEvent | PythonUpdateEvent
+  type PythonEvent = {}
   
   type PythonState = {
     id: number
@@ -60,24 +56,13 @@ class PythonBlockKind implements Langs.Block {
       return { id: id, block: <PythonBlockKind>block}
     },
   
-    update: (state:PythonState, event:PythonEvent) => {
-      switch(event.kind) {
-        case 'edit': 
-          // console.log("Python: Switch to edit mode!")
-          return { id: state.id, block: state.block }
-        case 'update': 
-          // console.log("Python: Set code to:\n%O", event.source);
-          let newBlock = pythonLanguagePlugin.parse(event.source)
-          return { id: state.id, block: <PythonBlockKind>newBlock}
-      }
-    },
+    update: (state:PythonState, event:PythonEvent) => state,
 
     render: (cell: Langs.BlockState, state:PythonState, context:Langs.EditorContext<PythonEvent>) => {
       let evalButton = h('button', { onclick:() => context.evaluate(cell) }, ["Evaluate"])
       let results = h('div', {}, [
         h('p', {
             style: "height:75px; position:relative", 
-            onclick:() => context.trigger({kind:'edit'})
           }, 
           [ ((cell.code==undefined)||(cell.code.value==undefined)) ? evalButton : ("Value is: " + JSON.stringify(cell.code.value)) ]),
       ]);
@@ -144,7 +129,7 @@ class PythonBlockKind implements Langs.Block {
         let headers = {'Content-Type': 'application/json'}
         let url = DATASTORE_URI.concat(pathname)
         try {
-          const response = await axios.get(url, headers);
+          const response = await axios.get(url, {headers: headers});
           console.log(response)
           return response.data
         }
@@ -157,7 +142,7 @@ class PythonBlockKind implements Langs.Block {
         let url = PYTHONSERVICE_URI.concat("/eval")
         let headers = {'Content-Type': 'application/json'}
         try {
-          const response = await axios.post(url, body, headers);
+          const response = await axios.post(url, body, {headers: headers});
           var results : Langs.ExportsValue = {}
           for(var df of response.data.frames) 
             // results[df.name] = await getValue(df.url)
@@ -224,7 +209,7 @@ class PythonBlockKind implements Langs.Block {
 			let headers = {'Content-Type': 'application/json'}
 			async function getExports() {
 				try {
-					const response = await axios.post(url,body, headers);
+					const response = await axios.post(url, body, {headers: headers});
 					// console.log(response.data.exports)
 					// console.log(response.data.imports)
 					for (var n = 0 ; n < response.data.exports.length; n++) {

--- a/client/src/languagePlugins/python/pythonPlugin.ts
+++ b/client/src/languagePlugins/python/pythonPlugin.ts
@@ -156,23 +156,20 @@ class PythonBlockKind implements Langs.Block {
 
       switch(pyNode.kind) {
         case 'code': 
-          var argDictionary:{[key: string]: string} = {}
-          let importedVars = "";
-          for (var i = 0; i < pyNode.antecedents.length; i++) {
-            let imported = <Graph.PyExportNode>pyNode.antecedents[i]
+          let importedFrames : { name:string, url:string }[] = [];
+          for (var ant of pyNode.antecedents) {
+            let imported = <Graph.ExportNode>ant
             console.log(imported);
-            let value = imported.value.data
-            console.log(value);
-            importedVars = importedVars.concat(imported.variableName + " = pd.DataFrame(" + JSON.stringify(value) + ")\n");
+            console.log(imported.value.data);
+            importedFrames.push({ name: imported.variableName, url: imported.value.url })
           }
-          // console.log(argDictionary)
-          // console.log(importedVars)
-          let src = importedVars.concat(pyNode.source)
+
+          let src = pyNode.source
           console.log(src)
           let hash = Md5.hashStr(src)
 			    let body = {"code": src,
 									"hash": hash,
-									"frames": {}}
+									"frames": importedFrames}
           return await getEval(body);
 
         case 'export':

--- a/client/src/languages.ts
+++ b/client/src/languages.ts
@@ -15,7 +15,7 @@ interface ExportsValue extends Value {
   [key:string]: Value
 }
 
-interface DataFrame {
+interface DataFrame extends Value {
   url : string
   data : any
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -38,32 +38,14 @@ var scopeDictionary : { [variableName: string]: Graph.ExportNode} = { };
 // 1. create 2 blocks, 1 py dataframe, 1 js read dataframe length
 let documents = 
   [ 
-    {"language": "markdown", 
-      "source": "# Testing Markdown\n1. Edit this block \n2. Shift+Enter to convert to *Markdown*"},
-    //  {"language": "javascript",
-    //  "source": "var a = 1; "},
-    //  {"language": "javascript",
-    //   "source": "var c = a+1;"},
-    {"language": "javascript",
-    "source": "var data_1998 = {\"profit\":[1,2,3], \"loss\":[4,5,6]}; console.log(data_1998.profit.length)"},
-    {"language": "javascript",
-    "source": "var profit = data_1998"},
-    {"language": "python",
-    "source": "loss = data_1998"},
-    // {"language": "javascript",
-    //   "source": "var c = a+1;"},
-    // {"language": "python",
-    // "source": "a = 1;"},
-    // {"language": "javascript",
-    //   "source": "var c = a + 1; var d = a;"}
-    {
-      "language": "python",
-      "source": "df = pd.DataFrame({\"a\":[\"1\",\"2\",\"3\"],\"b\":[\"4\",\"5\",\"6\"]})"
-    },
-    // {
-    //   "language": "javascript",
-    //   "source": "var len = {\"length\": df.length}"
-    // }
+    { "language": "markdown", "source": "First, we create one frame in JavaScript:" },
+    { "language": "javascript", "source": "var one = [{'name':'Joe', 'age':50}]" },
+    { "language": "markdown", "source": "Second, we create one frame in Python:" },
+    { "language": "python", "source": 'two = pd.DataFrame({"name":["Jim"], "age":[51]})' },
+    { "language": "markdown", "source": "Now, test if we can access both from JavaScript" },
+    { "language": "javascript", "source": "var joinJs = one.concat(two)"},
+    { "language": "markdown", "source": "Similarly, test if we can access both from Python" },
+    { "language": "python", "source": "joinPy = one.append(two)"} 
   ]
 
 interface NotebookAddEvent { kind:'add', id: number }

--- a/server/python/python_service.py
+++ b/server/python/python_service.py
@@ -60,10 +60,10 @@ def convert_from_pandas_df(dataframe):
         return dataframe
     row_list = []
     columns = list(dataframe.columns)
-    for row in range(len(dataframe.values)):
+    for index, row in dataframe.iterrows():
         this_row = {}
         for column in columns:
-            this_row[column] = cleanup(dataframe[column][row])
+            this_row[column] = cleanup(row[column])
         row_list.append(this_row)
     return row_list
 

--- a/server/python/python_service.py
+++ b/server/python/python_service.py
@@ -54,7 +54,10 @@ def convert_to_pandas_df(frame):
 def convert_from_pandas_df(dataframe):
     """
     converts pandas dataframe into wrattler format, i.e. list of rows.
+    If input is not a pandas dataframe, just return it unchanged.
     """
+    if not isinstance(dataframe, pd.DataFrame):
+        return dataframe
     row_list = []
     columns = list(dataframe.columns)
     for row in range(len(dataframe.values)):
@@ -213,9 +216,7 @@ def execute_code(code, input_val_dict, return_vars, verbose=False):
     if isinstance(func_output, collections.Iterable):
         results = []
         for item in func_output:
-            if isinstance(item, pd.DataFrame):
-                item = convert_from_pandas_df(item)
-            results.append(item)
+            results.append(convert_from_pandas_df(item))
         return results
     else:
         result = convert_from_pandas_df(func_output)

--- a/server/python/tests/fixtures.py
+++ b/server/python/tests/fixtures.py
@@ -1,0 +1,43 @@
+"""
+mock flask app and mock datastore for use in tests
+"""
+
+from flask import Flask
+from flask_restful import Api
+
+import pytest
+
+
+@pytest.fixture(scope='module')
+def demo_app():
+    """
+    setup a flask app
+    """
+    app = Flask(__name__)
+
+class MockDataStore(object):
+    def __init__(self):
+        self.data_dict = {}
+    def store(self,content, frame, hash):
+        self.data_dict[hash+"/"+frame] = content
+
+    def retrieve(self,frame, hash):
+        return self.data_dict[hash+"/"+frame]
+
+@pytest.fixture
+def mock_datastore(scope='module'):
+    ds = MockDataStore()
+    return ds
+
+
+
+def mock_write_frame(mock_datastore,data, frame_name,frame_hash):
+    mock_datastore.store(data,frame_name, frame_hash)
+    return True
+
+
+
+def mock_read_frame(mock_datastore, frame_name, frame_hash):
+    data = mock_datastore.retrieve(frame, hash)
+    print(data)
+    return data

--- a/server/python/tests/test_dataframes.py
+++ b/server/python/tests/test_dataframes.py
@@ -20,3 +20,19 @@ def test_convert_pandas():
     pd_df = convert_to_pandas_df(d_orig)
     d_new = convert_from_pandas_df(pd_df)
     assert(d_orig == d_new)
+
+
+def test_dont_convert_non_df():
+    """
+    Check that if we just give a number or a string or something else,
+    we get the same result back
+    """
+    x_orig = 345
+    x_conv = convert_to_pandas_df(x_orig)
+    x_new = convert_from_pandas_df(x_conv)
+    assert(x_orig == x_new)
+
+    y_orig = "testing"
+    y_conv = convert_to_pandas_df(y_orig)
+    y_new = convert_from_pandas_df(y_conv)
+    assert(y_orig == y_new)

--- a/server/python/tests/test_endpoints.py
+++ b/server/python/tests/test_endpoints.py
@@ -1,0 +1,34 @@
+"""
+test hitting the api endpoints.
+Use a test fixture to mock the datastore.
+"""
+
+import pytest
+
+
+class MockDataStore(object):
+    def __init__(self):
+        self.data_dict = {}
+    def store(self,content, frame, hash):
+        self.data_dict[hash+"/"+frame] = content
+
+    def retrieve(self,frame, hash):
+        return self.data_dict[hash+"/"+frame]
+
+@pytest.fixture
+def mock_datastore(scope='module'):
+    ds = MockDataStore()
+    return ds
+
+
+
+def mock_write_frame(mock_datastore,data, frame_name,frame_hash):
+    mock_datastore.store(data,frame_name, frame_hash)
+    return True
+
+
+
+def mock_read_frame(mock_datastore, frame_name, frame_hash):
+    data = mock_datastore.retrieve(frame, hash)
+    print(data)
+    return data

--- a/server/python/tests/test_endpoints.py
+++ b/server/python/tests/test_endpoints.py
@@ -3,32 +3,16 @@ test hitting the api endpoints.
 Use a test fixture to mock the datastore.
 """
 
-import pytest
+"""
+test the API endpoints using a mock datastore
+"""
 
-
-class MockDataStore(object):
-    def __init__(self):
-        self.data_dict = {}
-    def store(self,content, frame, hash):
-        self.data_dict[hash+"/"+frame] = content
-
-    def retrieve(self,frame, hash):
-        return self.data_dict[hash+"/"+frame]
-
-@pytest.fixture
-def mock_datastore(scope='module'):
-    ds = MockDataStore()
-    return ds
+from .fixtures import *
 
 
 
-def mock_write_frame(mock_datastore,data, frame_name,frame_hash):
-    mock_datastore.store(data,frame_name, frame_hash)
-    return True
+def test_exports():
+    pass
 
-
-
-def mock_read_frame(mock_datastore, frame_name, frame_hash):
-    data = mock_datastore.retrieve(frame, hash)
-    print(data)
-    return data
+def test_eval():
+    pass

--- a/server/python/tests/test_execute_code.py
+++ b/server/python/tests/test_execute_code.py
@@ -16,9 +16,10 @@ def test_execute_pd_concat():
                   "y": [{"b":4,"c": 2},{"b": 5,"c": 7}]}
     return_targets = find_assignments(input_code)["targets"]
     result = execute_code(input_code, input_vals, return_targets)
-    print(result)
-    assert(len(result) == 4)
-    assert(len(result[0]) == 3)
+    print(result)  # result will be a list of lists of dicts
+    assert(len(result) == 1) # only one output of function
+    assert(len(result[0]) == 4) # four 'rows' of dataframe
+    assert(len(result[0][0]) == 3) # three 'columns'
 
 
 def test_execute_simple_func():

--- a/server/python/tests/test_execute_code.py
+++ b/server/python/tests/test_execute_code.py
@@ -2,10 +2,11 @@
 Test that we can write some frames with simple variable
 assignments, then use these to do a simple join
 """
+import pandas as pd
 
 from python_service import execute_code, find_assignments
 
-def test_execute():
+def test_execute_pd_concat():
     """
     given an input dict of value assignments and a code snippet,
     substitute the values in, and evaluate.
@@ -18,3 +19,16 @@ def test_execute():
     print(result)
     assert(len(result) == 4)
     assert(len(result[0]) == 3)
+
+
+def test_execute_simple_func():
+    """
+    import numpy, and define a trivial function in the code snippet, which is
+    then used when filling a dataframe
+    """
+    input_code='import numpy\ndef squareroot(x):\n  return numpy.sqrt(x)\n\ndf= pd.DataFrame({\"a\":[numpy.sqrt(9),squareroot(12),13],\"b\":[14,15,16]})'
+    input_vals={}
+    return_targets = find_assignments(input_code)["targets"]
+    result = execute_code(input_code, input_vals, return_targets)
+    assert(result)
+    assert(isinstance(result,list))


### PR DESCRIPTION
Here is a summary of the updates:

1. https://github.com/wrattler/wrattler/commit/48722b76e53ab79a141a88eaa4d6d332b9f582f3 We should avoid using `require`, because TypeScript does not give us any static typing this way, so I converted a few uses of `require` to `import`. The types reveal some potential issues (like the `BindingPattern` case in JS parsing), which we might need to look into later. Also, I think we were passing headers to `axios` incorrectly.

   I also deleted some unused code related to Python and JavaScript events (they were never triggered and did not do anything, so I removed them and changed the `update` function to don't do anything).

2. https://github.com/wrattler/wrattler/commit/af9148b4adba381d1994a897e8efcfbaa5287ddc This is just to get the interfaces right, but no practical implications...

3. https://github.com/wrattler/wrattler/commit/64039f2f213cbd56c7f984b7ba82d07af42ffbc1 A nice test case that creates two data frames, one in JS and one in Python and then tries to append them both in Python and also in JavaScript. This should test our interop in both ways well.

4. https://github.com/wrattler/wrattler/commit/c8507d0b69bff0274f20379a7f5b246724c94554 We should not be passing data to Python directly as part of the source code. The whole point of the data store is that we should store data into data store and then pass the URL. The frames passed to the Python service are specified using the `frames` parameter (there is an [example in the design notes](https://github.com/wrattler/wrattler-design/blob/master/2018-04-07-prototype-notes.md#language-kernels)). I changed the code to do this properly.

The change (4) however breaks the Python service and I get an error:

> TypeError: list indices must be integers or slices, not str

I think this is a bug in Python service where it does not handle the `frames` parameter properly (@nbarlowATI can you investigate?)

@myyong There is also one more thing we should change and that's how we store data into the data store. Currently, this generates Python code and calls the Python service:

```
for (let value in values){
  let df = value.concat(" = pd.DataFrame(").concat(JSON.stringify(values[value])).concat(")\n")
  dfString = dfString.concat(df)
}
```

I can see why this works, but we should not need the Python service for this. We can write data to the data store directly by sending a normal HTTP `PUT` request [as documented in the docs](https://github.com/wrattler/wrattler-design/blob/master/2018-04-07-prototype-notes.md#data-store). The Python service does exactly this. 