### PR TITLE
Improve python parsing, add printout to console tab

### DIFF
--- a/client/public/cleanEHR_newCode.md
+++ b/client/public/cleanEHR_newCode.md
@@ -18,13 +18,13 @@ For the purposes of the analytical challenge we have to process and convert some
 time-varying and single-value fields need to be used in the same model, thus the former have been distilled into a few time-series descriptive variables 
 such as mean, standard deviation or min and max values.
 
-The pre-procesing in R returns two dataframes, one containing only the demographic fields and another including the time-series descriptive fields. 
+The pre-processing in R returns two dataframes, one containing only the demographic fields and another including the time-series descriptive fields. 
 
 ```r
 library(purrr)
 library(cleanEHR)
-# full dataset
 
+# download and read full dataset
 file <- paste(tempdir(), "/ccd.rdata", sep="")
 download.file("https://github.com/ropensci/cleanEHR/raw/master/data/sample_ccd.RData", file)
 load(file)
@@ -310,7 +310,8 @@ y_nts = dt_final["time_to_die"].values
 X_nts = dt_final_X.values
 ```
 
-Split datasets into training/testing samples.
+Split datasets into training/testing samples. Standardise both datasets and run the modelling. 
+
 
 ```python
 import sklearn
@@ -323,13 +324,6 @@ X_nts_train, X_nts_test, y_nts_train, y_nts_test = train_test_split(X_nts, y_nts
 # demographic + time series data
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.20, random_state=42)
 
-```
-
-Standardise both datasets and run the modelling. 
-```python
-
-# y_nts_train = y_nts_train
-# y_train = y_train
 # apply transformations to data: standardize X
 from sklearn.preprocessing import StandardScaler
 X_scaler = StandardScaler()
@@ -421,8 +415,6 @@ The dataset is almost divided in half with patients that survive the first 100 h
 
 
 ```python
-# In[19]:
-
 # Demographic only data"
 # Class 1; time of death within the first 100 hours'
 Class_1_nts = [round(dt_final[dt_final["survival_class"]==1].shape[0]/dt_final.shape[0],3)]
@@ -496,7 +488,7 @@ metrics_Rf_testing_nts=[metrics.accuracy_score(y_true_class, y_pred_class)]
 cnf_matrix_nts = metrics.confusion_matrix(y_nts_test_class, y_nts_pred_class)
 
 ```
-#### Visualise the confusion matrix for demographic only sample
+#### Visualise the confusion matrix for the sample with demographic only data
 
 ```javascript
 let xValues =  ['< 100 hours', '> 100 hours']
@@ -579,7 +571,7 @@ addOutput(function(id) {
   Plotly.newPlot(document.getElementById(id), [trace3], layout_nts);
 });
 ```
-classification for demographic plus time-series sample.
+Now we run the classification for the sample with demographic plus time-series data.
 ```python
 
 from sklearn.ensemble import RandomForestClassifier
@@ -605,7 +597,7 @@ cnf_matrix = metrics.confusion_matrix(y_test_class, y_pred_class)
 #Plot normalized confusion matrix
 
 ```
-#### Visualise the confusion matrix for demographic plus time-series sample
+#### Visualise the confusion matrix for the sample with demographic plus time-series data
 
 ```javascript
 let xValues_cnf_ = ['< 100 hours', '> 100 hours']

--- a/client/public/sample.md
+++ b/client/public/sample.md
@@ -39,6 +39,11 @@ Finally, test if we can access all from R:
 joinR <- rbind(rbind(one,two),three)
 ```
 
+```python
+from sklearn.linear_model import ElasticNet
+clf = ElasticNet()
+```
+
 On an unrelated note, try if TheGamma integration does anything at all:
 
 ```markdown

--- a/client/public/sample.md
+++ b/client/public/sample.md
@@ -11,6 +11,7 @@ Second, we create one frame in Python:
 
 ```python
 two = pd.DataFrame({"name":["Jim"], "age":[51]})
+print("Hello me")
 ```
 
 Finally, we create one more frame in R:
@@ -40,6 +41,6 @@ joinR <- rbind(rbind(one,two),three)
 
 On an unrelated note, try if TheGamma integration does anything at all:
 
-```thegamma
+```markdown
 1+2
 ```

--- a/client/src/definitions/values.ts
+++ b/client/src/definitions/values.ts
@@ -40,8 +40,7 @@ interface DataFrame extends Value {
 
 interface Printout extends Value {
   kind : "printout"
-  url : string
-  data : Array<string>
+  data : string
 }
 
 export {

--- a/client/src/definitions/values.ts
+++ b/client/src/definitions/values.ts
@@ -10,7 +10,7 @@
 * TODO
 */
 interface Value {
-  kind : "jsoutput" | "dataframe" | "exports" | "nothing"
+  kind : "jsoutput" | "dataframe" | "exports" | "nothing" | "printout"
 }
 
 /**
@@ -38,9 +38,16 @@ interface DataFrame extends Value {
   data : any
 }
 
+interface Printout extends Value {
+  kind : "printout"
+  url : string
+  data : Array<string>
+}
+
 export {
   Value, 
   ExportsValue,
   JavaScriptOutputValue,
+  Printout,
   DataFrame
 }

--- a/client/src/editors/preview.ts
+++ b/client/src/editors/preview.ts
@@ -2,9 +2,14 @@ import {h, VNode} from 'maquette';
 import * as Values from '../definitions/values'; 
 
 function printPreview(cellId:number, triggerSelect:(number) => void, selectedTable:number, cellValues:Values.ExportsValue) {
+  
   let tableNames:Array<string> = Object.keys(cellValues.exports)
-  let tabComponents = printTabs(triggerSelect, selectedTable, tableNames);
-  return h('div', {}, [ tabComponents, printCurrentValue(cellId, cellValues.exports[tableNames[selectedTable]],tableNames[selectedTable]) ]);
+  if (tableNames.length > 0) {
+    let tabComponents = printTabs(triggerSelect, selectedTable, tableNames);
+    return h('div', {}, [ tabComponents, printCurrentValue(cellId, cellValues.exports[tableNames[selectedTable]],tableNames[selectedTable]) ]);
+  }
+  else 
+    return h('div', {},[])
 }
 
 function printCurrentValue(cellId:number, value:Values.Value, tableName:string) {

--- a/client/src/editors/preview.ts
+++ b/client/src/editors/preview.ts
@@ -13,6 +13,9 @@ function printCurrentValue(cellId:number, value:Values.Value, tableName:string) 
     case "dataframe":
       let df = <Values.DataFrame>value
       return h('div', {}, [printCurrentTable(df.data, tableName)]);
+    case "printout":
+      let printout = <Values.Printout>value
+      return h('div', {}, [h('p', {innerHTML: printout.data.toLocaleString()}, [])])
     case "jsoutput":
       let js = <Values.JavaScriptOutputValue>value
       let callRender = (el) => js.render(el.id);

--- a/client/src/languages/external.ts
+++ b/client/src/languages/external.ts
@@ -97,11 +97,24 @@ export class externalLanguagePlugin implements Langs.LanguagePlugin {
       let headers = {'Content-Type': 'application/json'}
       try {
         let response = await axios.post(url, body, {headers: headers});
+        // console.log(response)
+        
         var results : Values.ExportsValue = { kind:"exports", exports:{} }
-        for(var df of response.data.frames) {
+        console.log(response.data.output.toString().length)
+        console.log(response.data.output.toString())
+        if (response.data.output.toString().length > 0){
+          let printouts : Values.Printout = { kind:"printout", data:response.data.output.toString() }
+          results.exports['printout'] = printouts
+        }
+        else {
+          let printouts : Values.Printout = { kind:"printout", data:"Placeholder" }
+          results.exports['printout'] = printouts
+        }
+        for(let df of response.data.frames) {
           let exp : Values.DataFrame = {kind:"dataframe", url:<string>df.url, data: await getValue(df.url)};
           results.exports[df.name] = exp
         }
+        
         return results;
       }
       catch (error) {

--- a/client/src/languages/external.ts
+++ b/client/src/languages/external.ts
@@ -100,16 +100,12 @@ export class externalLanguagePlugin implements Langs.LanguagePlugin {
         // console.log(response)
         
         var results : Values.ExportsValue = { kind:"exports", exports:{} }
-        console.log(response.data.output.toString().length)
-        console.log(response.data.output.toString())
+        
         if (response.data.output.toString().length > 0){
           let printouts : Values.Printout = { kind:"printout", data:response.data.output.toString() }
           results.exports['printout'] = printouts
         }
-        else {
-          let printouts : Values.Printout = { kind:"printout", data:"Placeholder" }
-          results.exports['printout'] = printouts
-        }
+        
         for(let df of response.data.frames) {
           let exp : Values.DataFrame = {kind:"dataframe", url:<string>df.url, data: await getValue(df.url)};
           results.exports[df.name] = exp

--- a/client/src/languages/external.ts
+++ b/client/src/languages/external.ts
@@ -103,12 +103,13 @@ export class externalLanguagePlugin implements Langs.LanguagePlugin {
         
         if (response.data.output.toString().length > 0){
           let printouts : Values.Printout = { kind:"printout", data:response.data.output.toString() }
-          results.exports['printout'] = printouts
+          results.exports['console'] = printouts
         }
         
         for(let df of response.data.frames) {
           let exp : Values.DataFrame = {kind:"dataframe", url:<string>df.url, data: await getValue(df.url)};
-          results.exports[df.name] = exp
+          if (Array.isArray(exp.data))
+            results.exports[df.name] = exp
         }
         
         return results;

--- a/server/python/app.py
+++ b/server/python/app.py
@@ -28,8 +28,6 @@ def handle_api_exception(error):
 def exports():
     data = json.loads(request.data.decode("utf-8"))
     imports_exports = analyze_code(data)
-
-    print("code is {}".format(data["code"]))
     return jsonify(imports_exports)
 
 @app.route("/eval", methods=['POST'])

--- a/server/python/python_service.py
+++ b/server/python/python_service.py
@@ -129,6 +129,8 @@ def find_assignments(code_string):
             if isinstance(node, ast.Assign):
                 _find_elements(node.targets, output_dict, "targets")
                 _find_elements(node.value, output_dict, "input_vals")
+            elif isinstance(node, ast.Call):
+                _find_elements(node.args, output_dict, "input_vals")
             elif isinstance(node, ast.Name) and parent:
                 output_dict[parent].append(node.id)
             elif isinstance(node, ast.FunctionDef):  ## don't go inside..
@@ -241,7 +243,7 @@ def execute_code(code, input_val_dict, return_vars, verbose=False):
     try:
         with stdoutIO() as s:
             func_output = eval('wrattler_f()')
-            return_dict["output"] = s.getvalue()
+            return_dict["output"] = s.getvalue().strip()
             if isinstance(func_output, collections.Iterable):
                 results = []
                 for item in func_output:

--- a/server/python/python_service.py
+++ b/server/python/python_service.py
@@ -131,6 +131,7 @@ def find_assignments(code_string):
                 _find_elements(node.value, output_dict, "input_vals")
             elif isinstance(node, ast.Call):
                 _find_elements(node.args, output_dict, "input_vals")
+                _find_elements(node.func, output_dict, "input_vals")
             elif isinstance(node, ast.Name) and parent:
                 output_dict[parent].append(node.id)
             elif isinstance(node, ast.FunctionDef):  ## don't go inside..

--- a/server/python/tests/test_execute_code.py
+++ b/server/python/tests/test_execute_code.py
@@ -61,7 +61,23 @@ def test_get_normal_output():
     result_dict = execute_code(input_code, input_vals, return_targets)
     output = result_dict["output"]
     assert(output)
+    assert(isinstance(output,str))
     assert("hello world" in output)
+
+def test_get_two_normal_outputs():
+    """
+    Write two simple print statement and test that we get a single output string with two lines
+    """
+    input_code='print("hello world")\nprint("hi again")\n'
+    input_vals={}
+    return_targets = find_assignments(input_code)["targets"]
+    result_dict = execute_code(input_code, input_vals, return_targets)
+    output = result_dict["output"]
+    assert(output)
+    assert(isinstance(output,str))
+    assert("hello world" in output)
+    assert("hi again" in output)
+    assert(output.count("\n")==1)
 
 
 def test_get_normal_output_in_func():
@@ -74,4 +90,5 @@ def test_get_normal_output_in_func():
     result_dict = execute_code(input_code, input_vals, return_targets)
     output = result_dict["output"]
     assert(output)
+    assert(isinstance(output,str))
     assert("hello funcky world" in output)

--- a/server/python/tests/test_parse_code.py
+++ b/server/python/tests/test_parse_code.py
@@ -66,3 +66,16 @@ def test_out_of_scope_assignments():
     result = analyze_code(testdata)
     print(result)
     assert(result["exports"]==["newx"])
+
+
+def test_non_assignment_imports():
+    """
+    variables can be used in statements that are not assignments..
+    """
+    code = "a.dosomething(b,c)" # b and c should be imports
+    testdata = {"code": code,
+                "frames": ["b","c"],
+                "hash": "irrelevant"}
+    result = analyze_code(testdata)
+    print(result)
+    assert(result["imports"] == ["b","c"])

--- a/server/python/tests/test_parse_code.py
+++ b/server/python/tests/test_parse_code.py
@@ -72,10 +72,25 @@ def test_non_assignment_imports():
     """
     variables can be used in statements that are not assignments..
     """
-    code = "a.dosomething(b,c)" # b and c should be imports
+    code = "a.dosomething(b,c)" # a, b and c should be imports
     testdata = {"code": code,
-                "frames": ["b","c"],
+                "frames": ["a","b","c"],
                 "hash": "irrelevant"}
     result = analyze_code(testdata)
     print(result)
-    assert(result["imports"] == ["b","c"])
+    assert(sorted(result["imports"]) == ["a","b","c"])
+
+
+
+def test_method_calling_imports():
+    """
+    variables can be used in statements that are not assignments..
+    """
+    code = "x = a.dosomething(b,c)" # a, b and c should be imports
+    testdata = {"code": code,
+                "frames": ["a","b","c"],
+                "hash": "irrelevant"}
+    result = analyze_code(testdata)
+    print(result)
+    assert(sorted(result["imports"]) == ["a","b","c"])
+    assert(result["exports"] == ["x"])


### PR DESCRIPTION
* Client displays "output" field of response in console tab of preview
* python service parser can now deal with arguments of function calls, e.g. a.fit(b,c) will identify b and c as potential imports.