### PR TITLE
Set max content length in data store (fix #86)

### DIFF
--- a/server/data-store/src/app.fsx
+++ b/server/data-store/src/app.fsx
@@ -70,6 +70,7 @@ match System.Environment.GetCommandLineArgs() |> Seq.tryPick (fun s ->
 | Some port ->
     let serverConfig =
       { Web.defaultConfig with
+          maxContentLength = 1024 * 1024 * 1024 
           bindings = [ HttpBinding.createSimple HTTP "0.0.0.0" port ] }
     Web.startWebServer serverConfig app
 | _ -> ()


### PR DESCRIPTION
This should fix the data store issues, but Docker was doing funny things on my machine, so I have not fully tested it yet. It seems to be allowing upload of large data now though!