### PR TITLE
User interface tweaks & recover caching

### DIFF
--- a/client/public/index.css
+++ b/client/public/index.css
@@ -87,23 +87,27 @@ div.controls {
 -----------------------------------------------------------------------------*/
 
 div.tabs {
-	overflow: hidden; 
-	background-color: #f1f1f1;
-	padding:10px 5px 10px 5px;
+	border-bottom:solid 5px #dfdfdf;
+	height:27px;
+	margin-top:5px;
 }
 div.tabs button {
 	background-color: inherit;
 	float: left;
 	border: none;
+	border-bottom:solid 5px #c0c0c0;
 	outline: none;
+	margin:0px 10px 0px 0px;
 	cursor: pointer;
-	padding: 3px 20px 6px 0px;
-	font-size: 17px;
+	font-size:10pt;
+	font-weight:bold;
+	color:#c0c0c0;
 }
 div.tabs button.selected {
-	font-weight:bold;
+	color:#878787;
+	border-bottom-color:#878787;	
 }
-																							
+																						
 div.editor {
 	border-left-style: double;
 	border-left-color: grey;

--- a/client/public/index.css
+++ b/client/public/index.css
@@ -1,7 +1,90 @@
-img {
-	width:3%; /* you can use % */
-	height: auto;
+@import url('https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono');
+
+/* ----------------------------------------------------------------------------
+	General notebook and cells styles	
+-----------------------------------------------------------------------------*/
+
+body { 
+	font-family:Roboto;
+	background:#f0f0f0;
 }
+#paper {
+	margin: auto;
+	padding:0px;
+}
+div.cell {
+	background:white;
+	border-left-style: solid;
+	border-left-width: 5px;
+	border-right-style: solid;
+	border-right-width: 5px;
+	width:100%;
+	padding:0px 25px 0px 25px;
+}
+div.icons-bar {
+	height:25px;
+	margin-top:10px;
+	overflow:hidden;
+	margin-left:-15px;
+}
+div.content-bar {
+	padding:10px 0px 10px 0px;
+}
+div.controls-bar {
+	height:25px;
+	overflow:hidden;
+	margin-right:-15px;
+}
+div.icons {
+	float:left;
+}
+div.controls {
+	float:right;
+}
+.controls-bar a, .icons-bar span {
+	font-size:10pt;
+	font-weight:bold;
+}
+.controls-bar a {
+	margin:0px 0px 0px 15px;
+	cursor: pointer;
+}
+.icons-bar span {
+	margin:0px 0px 0px 0px;
+}
+.controls-bar .fa, .icons-bar .fa, .controls-bar .fab, .icons-bar .fab {
+	font-size:10pt;
+	margin-right:5px;
+}
+
+.cell-c0 .controls-bar a, .cell-c0 .icons-bar span, .cell-c0 .controls-bar .fa, 
+	.cell-c0 .icons-bar .fa, .cell-c0 .controls-bar .fab, .cell-c0 .icons-bar .fab { color:#8DD3C7; }
+.cell-c0 { border-color:#8DD3C7; }
+.cell-c0 a:hover, .cell-c0 a:hover i { color:#4F9589 !important; }
+
+.cell-c1 .controls-bar a, .cell-c1 .icons-bar span, .cell-c1 .controls-bar .fa, 
+	.cell-c1 .icons-bar .fa, .cell-c1 .controls-bar .fab, .cell-c1 .icons-bar .fab { color:#BEBADA; }
+.cell-c1 { border-color:#BEBADA; }
+.cell-c1 a:hover, .cell-c1 a:hover i { color:#827E9E !important; }
+
+.cell-c2 .controls-bar a, .cell-c2 .icons-bar span, .cell-c2 .controls-bar .fa, 
+	.cell-c2 .icons-bar .fa, .cell-c2 .controls-bar .fab, .cell-c2 .icons-bar .fab { color:#FDB462; }
+.cell-c2 { border-color:#FDB462; }
+.cell-c2 a:hover, .cell-c2 a:hover i { color:#C27927 !important; }
+
+.cell-c3 .controls-bar a, .cell-c3 .icons-bar span, .cell-c3 .controls-bar .fa, 
+	.cell-c3 .icons-bar .fa, .cell-c3 .controls-bar .fab, .cell-c3 .icons-bar .fab { color:#B3DE69; }
+.cell-c3 { border-color:#B3DE69; }
+.cell-c3 a:hover, .cell-c3 a:hover i { color:#7AA530 !important; }
+
+.cell-c4 .controls-bar a, .cell-c4 .icons-bar span, .cell-c4 .controls-bar .fa, 
+	.cell-c4 .icons-bar .fa, .cell-c4 .controls-bar .fab, .cell-c4 .icons-bar .fab { color:#FB8072; }
+.cell-c4 { border-color:#FB8072; }
+.cell-c4 a:hover, .cell-c4 a:hover i { color:#B13628 !important; }
+
+/* ----------------------------------------------------------------------------
+	
+-----------------------------------------------------------------------------*/
 
 div.tabs {
 	overflow: hidden; 
@@ -27,7 +110,6 @@ div.editor {
 	padding: 5px;
 	margin: 10px;
 	height: 50vh;
-	/* overflow: scroll; */
 }
 
 div.output.rendered {
@@ -62,51 +144,6 @@ div.editor {
 	display: none;
 }
 
-div.cell{
-	border-left-style: solid;
-	border-left-width: 5px;
-	padding: 5px 5px 5px 15px;
-	width:100%;
-}
-
-div.cell:nth-child(odd){
- /* border-left-color: gainsboro;  */
- border-left-color: #798893
- /* border-left-color:#0065AB */
-}
-
-div.cell:nth-child(even){
-	/* border-left-color: grey; */
-	border-left-color: #A6D8E7
-}
-
-div.controls {
-	float:right;
-	background: #C1CDD4;
-	/* margin:10px; */
-}
-
-div.controlsBar {
-	margin:20px;
-	padding:10px;
-	position: relative;
-	border-color: #C1CDD4;
-	border-style: solid;
-}
-
-
-
-.vertical-center {
-	margin: 0;
-	/* position: absolute; */
-	top: 50%;
-	/* -ms-transform: translateY(-50%); */
-	/* transform: translateY(-50%); */
-  }
-
-.icon {
-	color: #798893;
-}
 
 div.table-container {
 	overflow-x:auto;
@@ -133,15 +170,6 @@ div.table-container::-webkit-scrollbar-thumb {
 	border-radius:4px;
 	background-color:#c0c0c0;
 }
-.preview-button {
-	margin-top:20px;
-	margin-bottom:20px;
-	background:#C1CDD4;
-}
-
-.add-button {
-	background:#C1CDD4;
-}
 
 
 /* code.indicator {
@@ -167,16 +195,6 @@ button.delete {
 	margin:3px;
 }
 
-body{
-  color:#000;
-  /* background-color:gainsboro; */
-    
-}
-
-#paper {
-  margin: auto;
-}
-
 .plot {
 	width: 50%;
 	display: block;
@@ -187,7 +205,6 @@ body{
 	#paper { 
 		min-width: 90%; 
 		max-width: 90%;
-		/* background-color: red; */
 	}
  }
 
@@ -195,7 +212,6 @@ body{
 	#paper { 
 		min-width: 85%; 
 		max-width: 85%;
-		/* background-color: blue; */
 	}
  }
 
@@ -203,7 +219,6 @@ body{
 	#paper { 
 		min-width: 95%; 
 		max-width: 95%;
-		/* background-color: green; */
 	}
  }
 
@@ -211,7 +226,6 @@ body{
 	#paper { 
 		min-width: 70%; 
 		max-width: 70%;
-		/* background-color: green; */
 	}
  }
 

--- a/client/public/index.md
+++ b/client/public/index.md
@@ -1,0 +1,9 @@
+```markdown
+# Welcome to Wrattler
+
+Here are some examples you can look at:
+
+ * [Hello world sample](/?sample)
+ * More comming soon
+ 
+```

--- a/client/src/definitions/graph.ts
+++ b/client/src/definitions/graph.ts
@@ -27,6 +27,8 @@ interface Node {
   /**  The evaluated value associated with this node */
   value: Values.Value | null
 
+  hash: string
+  
   errors: Error[]
 }
 
@@ -83,6 +85,10 @@ interface ExternalExportNode extends ExportNode {
 
 type ExternalNode = ExternalCodeNode | ExternalExportNode
 
+interface NodeCache {
+  tryFindNode(node:Node) : Node
+}
+
 export {
   Node,
   ExportNode,
@@ -92,5 +98,6 @@ export {
   ExternalNode,
   ExternalExportNode,
   ExternalCodeNode,
-  Error
+  Error,
+  NodeCache
 }

--- a/client/src/definitions/languages.ts
+++ b/client/src/definitions/languages.ts
@@ -53,7 +53,7 @@ interface LanguagePlugin {
    * construct a dependency graph for the given block. Returns a node representing the
    * code block and a list of exported variables (to be added to the scope)
    */
-  bind(scopeDictionary:{}, block: Block) : Promise<BindingResult>
+  bind(cache:Graph.NodeCache, scope:ScopeDictionary, block: Block) : Promise<BindingResult>
 
   /**
    * Given cell:Block, return string of source to be used for saving document in markdown

--- a/client/src/definitions/state.ts
+++ b/client/src/definitions/state.ts
@@ -1,8 +1,9 @@
 import * as Langs from './languages'
 
 declare type NotebookState = {
-    cells: Langs.BlockState[]
-    counter: number
-  }
+  cells: Langs.BlockState[]  
+  counter: number
+  expandedMenu : number
+}
 
 export {NotebookState}

--- a/client/src/definitions/state.ts
+++ b/client/src/definitions/state.ts
@@ -5,10 +5,7 @@ declare type NotebookState = {
   cells: Langs.BlockState[]  
   counter: number
   expandedMenu : number
-<<<<<<< HEAD
   cache: Graph.NodeCache
-=======
->>>>>>> tp-uitweaks
 }
 
 export {NotebookState}

--- a/client/src/definitions/state.ts
+++ b/client/src/definitions/state.ts
@@ -1,8 +1,11 @@
 import * as Langs from './languages'
+import * as Graph from './graph';
 
 declare type NotebookState = {
-    cells: Langs.BlockState[]
-    counter: number
-  }
+  cells: Langs.BlockState[]  
+  counter: number
+  expandedMenu : number
+  cache: Graph.NodeCache
+}
 
 export {NotebookState}

--- a/client/src/editors/editor.ts
+++ b/client/src/editors/editor.ts
@@ -12,7 +12,7 @@ function createMonaco(el, lang, source, rebind) {
     overviewRulerLanes: 0,
     lineDecorationsWidth: "0ch",
     fontSize: 14,
-    fontFamily: 'Monaco',
+    fontFamily: 'Roboto Mono',
     lineNumbersMinChars: 2,
     lineHeight: 20,
     lineNumbers: "on",
@@ -34,7 +34,7 @@ function createMonaco(el, lang, source, rebind) {
 
 function createEditor(lang:string, source:string, cell:Langs.BlockState, context:Langs.EditorContext<any>) {
   let afterCreateHandler = (el) => { 
-    let rebind = (code) => context.rebindSubsequent(cell, code)
+    let rebind = (code:string) => context.rebindSubsequent(cell, code)
     let ed = createMonaco(el, lang, source, rebind)
 
     let lastHeight = 100;
@@ -55,7 +55,7 @@ function createEditor(lang:string, source:string, cell:Langs.BlockState, context
     window.addEventListener("resize", resizeEditor)
     setTimeout(resizeEditor, 100)
   }
-  return h('div', { style: "height:100px; margin:20px 0px 10px 0px;", id: "editor_" + cell.editor.id.toString(), afterCreate:afterCreateHandler }, [ ])
+  return h('div', { id: "editor_" + cell.editor.id.toString(), afterCreate:afterCreateHandler }, [ ])
 }
 
 export {

--- a/client/src/languages/markdown.ts
+++ b/client/src/languages/markdown.ts
@@ -5,6 +5,7 @@ import * as Langs from '../definitions/languages';
 import * as Graph from '../definitions/graph'; 
 import { Value } from '../definitions/values';
 import { Statement } from 'typescript';
+import { Md5 } from 'ts-md5';
 
 // ------------------------------------------------------------------------------------------------
 // Markdown plugin
@@ -144,10 +145,13 @@ class MarkdownBlockKind implements Langs.Block {
     parse: (code:string) => {
       return new MarkdownBlockKind(code);
     },
-    bind: async (code: Langs.Block) : Promise<Langs.BindingResult> => {
+    bind: async (cache, scope, block: Langs.Block) : Promise<Langs.BindingResult> => {
+      let mdBlock:MarkdownBlockKind = <MarkdownBlockKind> block
+      console.log(block)
       let node:Graph.Node = {
         language:"markdown", 
         antecedents:[],
+        hash:<string>Md5.hashStr(mdBlock.source),
         value: null,
         errors: []
       }

--- a/client/src/languages/markdown.ts
+++ b/client/src/languages/markdown.ts
@@ -75,30 +75,22 @@ class MarkdownBlockKind implements Langs.Block {
           let ed = monaco.editor.create(el, {
             value: state.block.source,
             language: 'markdown',
-            // scrollBeyondLastLine: false,
+            scrollBeyondLastLine: false,
             theme:'vs',
+            minimap: { enabled: false },
+            overviewRulerLanes: 0,
+            lineDecorationsWidth: "0ch",
+            fontSize: 14,
+            fontFamily: 'Roboto Mono',
+            lineNumbersMinChars: 2,
+            lineHeight: 20,
+            lineNumbers: "on",
             scrollbar: {
-              // Subtle shadows to the left & top. Defaults to true.
-              useShadows: false,
-          
-              // Render vertical arrows. Defaults to false.
               verticalHasArrows: true,
-              // Render horizontal arrows. Defaults to false.
               horizontalHasArrows: true,
-          
-              // Render vertical scrollbar.
-              // Accepted values: 'auto', 'visible', 'hidden'.
-              // Defaults to 'auto'
-              vertical: 'visible',
-              // Render horizontal scrollbar.
-              // Accepted values: 'auto', 'visible', 'hidden'.
-              // Defaults to 'auto'
-              horizontal: 'visible',
-          
-              verticalScrollbarSize: 17,
-              horizontalScrollbarSize: 17,
-              arrowSize: 30
-            }
+              vertical: 'none',
+              horizontal: 'none'
+            }        
           });    
           numLines = ed['viewModel'].lines.lines.length;
   
@@ -132,7 +124,7 @@ class MarkdownBlockKind implements Langs.Block {
         }
         return h('div', {}, [
           // h('div', { style: "height:"+heightRequired+"px", id: "editor_" + state.id.toString(), afterCreate:afterCreateHandler }, [ ])
-          h('div', { style: "height:75px; padding-top: 20px; ", id: "editor_" + state.id.toString(), afterCreate:afterCreateHandler }, [ ])
+          h('div', { id: "editor_" + state.id.toString(), afterCreate:afterCreateHandler }, [ ])
         ] )      
       }
     }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -26,10 +26,6 @@ languagePlugins["javascript"] = javascriptLanguagePlugin;
 languagePlugins["python"] = new externalLanguagePlugin("python", PYTHONSERVICE_URI);
 languagePlugins["r"] = new externalLanguagePlugin("r", RSERVICE_URI);
 // languagePlugins["thegamma"] = gammaLangaugePlugin;
-<<<<<<< Updated upstream
-var scopeDictionary : { [variableName: string]: Graph.ExportNode} = { };
-=======
->>>>>>> Stashed changes
 
 interface NotebookAddEvent { kind:'add', id: number, language:string }
 interface NotebookRemoveEvent { kind:'remove', id: number }

--- a/client/src/services/documentService.ts
+++ b/client/src/services/documentService.ts
@@ -69,7 +69,7 @@ async function getNamedDocument(): Promise<DocumentElement[]> {
       return response.data
     }
 
-    let sourceFile = ""
+    let sourceFile = "index"
     if (window.location.search.slice(1).length > 0){
       sourceFile = window.location.search.slice(1)
     }


### PR DESCRIPTION
### User interface tweaks

I did various user interface tweaks - making Wrattler look a bit more like the early prototype (because that way, I could just steal design there rather than trying to come up with something new).

![ww](https://user-images.githubusercontent.com/485413/54574484-64916000-49e8-11e9-9e81-562ee45d1d2d.png)

### Default page
I also added support for default page - when you go to http://localhost:8080, the default `index.md` file gets loaded now (and we can use this to add links to other pages).

### Recover caching support
When testing things, I noticed that Wrattler stopped doing the thing where if you modified a cell, it would only delete results for cells that dependend on the given cell. I guess we always did this in an imperfect way (by checking the indices of cells) and we removed that at some point.

I think this is one of the really important things we should show, so I tried to recover that by adding a somewhat more proper caching mechanism. It works on http://localhost:8080/?sample - when you evaluate all cells and modify some, you'll see that only results of those that depend on it disappear.

BUT, this is quite a large change, so I'd really appreaciate some testing of this!
