### PR TITLE
Add a Racket service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 script:
   - docker run wrattler_wrattler_r_service /bin/bash -c "Rscript run-tests.r"
   - docker run wrattler_wrattler_python_service /bin/bash -c "export WRATTLER_LOCAL_TEST=True;pytest -s"
+  - docker run wrattler_wrattler_racket_service /bin/bash -c "raco test ."
 
 after_success:
   - docker-compose down

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -25,6 +25,7 @@ languagePlugins["markdown"] = markdownLanguagePlugin;
 languagePlugins["javascript"] = javascriptLanguagePlugin;
 languagePlugins["python"] = new externalLanguagePlugin("python", PYTHONSERVICE_URI);
 languagePlugins["r"] = new externalLanguagePlugin("r", RSERVICE_URI);
+languagePlugins["racket"] = new externalLanguagePlugin("racket", RACKETSERVICE_URI);
 // languagePlugins["thegamma"] = gammaLangaugePlugin;
 
 interface NotebookAddEvent { kind:'add', id: number, language:string }
@@ -227,11 +228,15 @@ async function update(state:State.NotebookState, evt:NotebookEvent) : Promise<St
           // newDocument.source =  newDocument.source.concat('\n# camilla <- data.frame(name = "camilla", age=17, mood="apprehensive")')
           break
         }
+        case 'racket': {
+          newDocument.source = ";; This is a Racket cell \n";
+          break
+        }
         case 'javascript': {
           newDocument.source = "// This is a javascript cell. \n//var js"+newId+" = [{'id':"+newId+", 'language':'javascript'}]";
           // newDocument.source =  newDocument.source.concat('\n// var may = [{"name":"may", "age":40, "mood":"terrified"}]')
           break
-        } 
+        }
       }
       console.log(newDocument)
       let lang = languagePlugins[newDocument.language];

--- a/client/src/services/documentService.ts
+++ b/client/src/services/documentService.ts
@@ -26,7 +26,7 @@ async function getDocument(paragraph:string): Promise<DocumentElement[]> {
   }
 
   function getCellLanguage(codeCell: string) {
-    let listOfLanguages = ["javascript", "python", "r", "thegamma"] 
+    let listOfLanguages = ["javascript", "python", "r", "racket", "thegamma"] 
     for (var l = 0; l < listOfLanguages.length; l++) {
       let languageMarker = "```".concat(listOfLanguages[l])
       let languageMarkerBegin = codeCell.indexOf(languageMarker)
@@ -85,6 +85,7 @@ function saveDocument(state:State.NotebookState):string
   languagePlugins["javascript"] = javascriptLanguagePlugin;
   languagePlugins["python"] = new externalLanguagePlugin("python", "PYTHONSERVICE_URI");
   languagePlugins["r"] = new externalLanguagePlugin("r", "RSERVICE_URI");
+  languagePlugins["racket"] = new externalLanguagePlugin("racket", "RACKETSERVICE_URI");
   for (let c = 0; c < state.cells.length; c++){
     content = content.concat(languagePlugins[state.cells[c].editor.block.language].save(state.cells[c].editor.block))
   }

--- a/client/src/services/documentService.ts
+++ b/client/src/services/documentService.ts
@@ -26,7 +26,7 @@ async function getDocument(paragraph:string): Promise<DocumentElement[]> {
   }
 
   function getCellLanguage(codeCell: string) {
-    let listOfLanguages = ["javascript", "python", "r", "racket", "thegamma"] 
+    let listOfLanguages = ["javascript", "python", "racket", "r", "thegamma"] 
     for (var l = 0; l < listOfLanguages.length; l++) {
       let languageMarker = "```".concat(listOfLanguages[l])
       let languageMarkerBegin = codeCell.indexOf(languageMarker)

--- a/client/tools/webpack.config.common.js
+++ b/client/tools/webpack.config.common.js
@@ -89,6 +89,7 @@ function getPlugins(isProduction) {
     new webpack.DefinePlugin({
       PYTHONSERVICE_URI: JSON.stringify(typeof(process.env.PYTHONSERVICE_URI)=="undefined"?"http://localhost:7101":process.env.PYTHONSERVICE_URI),
       RSERVICE_URI: JSON.stringify(typeof(process.env.RSERVICE_URI)=="undefined"?"http://localhost:7103":process.env.RSERVICE_URI),
+      RACKETSERVICE_URI: JSON.stringify(typeof(process.env.RACKETSERVICE_URI)=="undefined"?"http://localhost:7104":process.env.RACKETSERVICE_URI),
       DATASTORE_URI: JSON.stringify(typeof(process.env.DATASTORE_URI)=="undefined"?"http://localhost:7102":process.env.DATASTORE_URI)
     })
   ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     entrypoint: /bin/bash
     command: "./entrypoint.sh"
     environment:
+     - RACKETSERVICE_URI=http://localhost:7104
      - PYTHONSERVICE_URI=http://localhost:7101
      - RSERVICE_URI=http://localhost:7103
      - DATASTORE_URI=http://localhost:7102
@@ -48,6 +49,18 @@ services:
     environment:
       - DATASTORE_URI=http://wrattler_wrattler_data_store_1:7102
       - R_SERVICE_DEBUG=True
+    networks:
+    - wrattler_nw
+
+  wrattler_racket_service:
+    container_name: wrattler_wrattler_racket_service_1
+    build:
+      context: server/racket
+      dockerfile: Dockerfile
+    ports:
+    - "7104:7104"
+    environment:
+      - DATASTORE_URI=http://wrattler_wrattler_data_store_1:7102
     networks:
     - wrattler_nw
 

--- a/server/racket/Dockerfile
+++ b/server/racket/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:16.04
+RUN apt-get update && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:plt/racket && apt-get update && apt-get install -y racket
+ADD . /wrattler-racket-service
+WORKDIR /wrattler-racket-service
+RUN raco pkg install --auto
+
+EXPOSE 7104
+CMD ["./start-racket-service"]

--- a/server/racket/README.md
+++ b/server/racket/README.md
@@ -1,0 +1,19 @@
+## Racket service for Wrattler
+
+Requires:
+
+ - [Racket](https://racket-lang.org/) version 7.1 or greater
+ - the Racket [data-frame](https://pkgs.racket-lang.org/package/data-frame) package (install with `raco pkg install data-frame`)
+
+Start the server (by default on port 7104) by running
+```
+./start-racket-service
+```
+from within this directory.
+
+### Limitations
+
+ - no attempt at integrating it with the front end
+ - doesn't use CORS
+ - no plots/figures
+ - frames imported by a cell are always re-exported

--- a/server/racket/info.rkt
+++ b/server/racket/info.rkt
@@ -1,0 +1,3 @@
+#lang info
+(define collection "wrattler-racket-service")
+(define deps '("data-frame"))

--- a/server/racket/main.rkt
+++ b/server/racket/main.rkt
@@ -1,0 +1,295 @@
+#lang racket
+
+(provide start-racket-service)
+
+(require json
+         data-frame
+         syntax/strip-context
+         net/url
+         net/url-structs
+         web-server/servlet
+         web-server/servlet-env)
+
+;; Provides an alternative form of #%top that doesn't error on unbound
+;; identifiers.  Used when identifying the "imports" of a cell.
+(module undef-top racket/base
+  (define undefined 'undef)
+  (define-syntax-rule (#%top . x) '(undefined x))
+  (provide #%top undefined))
+
+(require (only-in 'undef-top undefined))
+
+(module+ test (require rackunit))
+
+(define current-datastore (make-parameter "http://localhost:7102"))
+
+(define (datastore-request-url hsh name)
+  (string-join (list (current-datastore) hsh name) "/"))
+
+;; Retrieve a frame (: jsexpr?) from the url as a string (url-str)
+;; Used for querying the data-store
+(define (retrieve-frame url-str)
+  (bytes->jsexpr (port->bytes (get-pure-port (string->url url-str)))))
+
+;; store-frame : url? jsexpr? -> boolean?
+(define (store-frame url val)
+  ;; get headers from the following, and check for error
+  (eq? (hash-ref (string->jsexpr
+                  (port->string
+                   (put-pure-port url (jsexpr->bytes val))))
+                 'status_code)
+       200))
+
+(define ((hash-keys-exactly? . ks) h)
+  (equal? (list->set (hash-keys h)) (apply set ks)))
+
+(define (string->syntax str)
+  (read-syntax #f (open-input-string str)))
+
+(define (id->string id)
+  (symbol->string (syntax->datum id)))
+
+(define (response/json js)
+  (response/xexpr (jsexpr->string js)))
+
+(define (response/404)
+  (response 404 #"File not found" (current-seconds)
+            TEXT/HTML-MIME-TYPE '() void))
+
+;;; data-frame <-> jsexpr conversions
+;; Try to convert data (: jsexpr?) to a data-frame, else return data
+(define (jsexpr->maybe-df data)
+  (if (and (list? data)
+           (andmap hash? data)
+           (andmap jsexpr? data)
+           (andmap (λ (maybe-row) (equal? (hash-keys (car data))
+                                          (hash-keys maybe-row)))
+                   data))
+      (let ([col-names (hash-keys (car data))]
+            [df (make-data-frame)])
+        (for ([col-name col-names])
+          (define series (make-series
+                          (symbol->string col-name)
+                          #:data (for/vector ([row data])
+                                   (hash-ref row col-name))))
+          (df-add-series df series))
+        df)
+      data))
+
+(define (data-frame->hashes df)
+  (define all-series (df-series-names df))
+  (for/list ([row (apply in-data-frame/list df all-series)])
+    (make-hash (map (λ (k v) (cons (string->symbol k) v)) all-series row))))
+
+;; If df is a data-frame then attempt to convert it to a jsexpr.  If
+;; this fails, or if df is not a data-frame, then return (void).
+(define/contract (maybe-df->jsexpr df)
+  (-> any/c (or/c jsexpr? void?))
+  (when (data-frame? df)
+    (let ([df-as-hash-tables (data-frame->hashes df)])
+      (when (jsexpr? df-as-hash-tables)
+        df-as-hash-tables))))
+
+(module+ test
+  (define (df-equal? df1 df2)
+    (and (equal? (df-series-names df1) (df-series-names df2))
+         (for/and ([row1 (apply in-data-frame/list df1 (df-series-names df1))]
+                   [row2 (apply in-data-frame/list df2 (df-series-names df2))])
+           (equal? row1 row2))))
+   
+  
+  (test-case "data-frame <-> jsexpr"
+    (let ([df (make-data-frame)])
+      (df-add-series df (make-series "a" #:data #(1 2 3)))
+      (df-add-series df (make-series "b" #:data #(4 5 6)))
+      (let ([actual   (maybe-df->jsexpr df)]
+            [expected (list (hash 'b 4 'a 1)
+                            (hash 'b 5 'a 2)
+                            (hash 'b 6 'a 3))])
+        (check-equal? (map hash->list actual)
+                      (map hash->list expected)))
+
+      (define df* (jsexpr->maybe-df (maybe-df->jsexpr df)))
+      (check df-equal? df df*))
+     
+      (check-equal? (maybe-df->jsexpr 1) (void))
+      (check-equal? (maybe-df->jsexpr 'a) (void))
+      (check-equal? (maybe-df->jsexpr '(1 2 3)) (void))
+
+    (let ([df (make-data-frame)])
+      (df-add-series df (make-series "x" #:data #("1" -1)))
+      (df-add-series df (make-series "y" #:data #(2 0.0)))
+      (df-add-series df (make-series "z" #:data #(4.0 "zero")))
+      (define df* (jsexpr->maybe-df (list (hash 'x "1" 'y 2 'z 4.0)
+                                          (hash 'x -1 'y 0.0 'z "zero"))))
+      (check df-equal? df df*))
+
+    (check-equal? (jsexpr->maybe-df 5) 5)
+    (check-equal? (jsexpr->maybe-df (hash 'x 1 'y 2)) (hash 'x 1 'y 2))
+    ))
+
+;; stx must be a fully-expanded top-level module form, where each
+;; unbound top-level identifier id has replaced with '(undefined id).
+;; See `#%top` and `undefined` from module undef-top.
+(define (unbound-ids stx)
+  (define (recurse stx)
+    (syntax-case stx (undefined)
+      ['(undefined x) (list #'x)]
+      [(x . xs) (append (recurse #'x) (recurse #'xs))]
+      [id '()]))
+  (remove-duplicates (recurse stx) free-identifier=?))
+
+;; Identify the top-level bindings of stx within the namespace ns
+(define (top-level-bindings stx ns)
+  (define (recurse stx)
+    (define stx*
+      (parameterize ([current-namespace ns])
+        (expand-to-top-form stx)))
+    (syntax-case stx* (begin define-values)
+      [(define-values (var ...) expr) (syntax-e #'(var ...))]
+      [(begin form ...)
+       (apply append (map recurse (syntax-e #'(form ...))))]
+      [_ '()]))
+  (remove-duplicates (recurse stx) free-identifier=?))
+
+(define (imports/exports payload)
+  (define ns (make-base-namespace))
+  (define code-raw (string->syntax (hash-ref payload 'code)))
+
+  ;; Expand the code inside a module (so that lifted defines are
+  ;; handled as we want them to be), but replace #%top so that it
+  ;; doesn't cause an error on unbound identifiers and instead wraps
+  ;; the id with a form that can be picked up by `unbound-ids`
+  (define code-expanded
+    (with-syntax ([code-raw code-raw])
+      (parameterize ([current-namespace ns])
+        (expand (strip-context
+                 #'(module tmp racket/base
+                     (require data-frame)
+                     (require (only-in (submod "main.rkt" undef-top) #%top))
+                     code-raw))))))
+
+  (define explicit-exports (top-level-bindings code-raw ns))
+  (define imports (unbound-ids code-expanded))
+  (values imports (append imports explicit-exports)))
+
+(define jsexpr-dict/c (hash/c symbol? jsexpr?))
+(define payload/c        (and/c jsexpr-dict/c
+                                (hash-keys-exactly? 'code 'frames 'hash)))
+(define exports-result/c (and/c jsexpr-dict/c
+                                (hash-keys-exactly? 'imports 'exports)))
+(define eval-result/c    (and/c jsexpr-dict/c
+                                (hash-keys-exactly? 'output 'frames 'figures)))
+
+(define/contract (exports/jsexpr payload)
+  (-> payload/c exports-result/c)
+  (let-values ([(imports exports) (imports/exports payload)])
+    (hash 'imports (map id->string imports)
+          'exports (map id->string exports))))
+
+;; The namespace in which a cell's contents are to be evaluated
+(define/contract (make-cell-namespace bindings)
+  (-> (hash/c symbol? any/c) namespace?)
+  (let ([ns (make-base-namespace)])
+    (namespace-attach-module (current-namespace) 'data-frame ns)
+    (namespace-require 'data-frame ns)
+    (for ([(id val) bindings])
+      (namespace-set-variable-value! id val #f ns))
+    ns))
+
+(define/contract (eval/jsexpr payload)
+  (-> payload/c eval-result/c)
+  (define cell-contents (hash-ref payload 'code))
+  (define code-hash     (hash-ref payload 'hash))
+  (define frame-urls    (hash-ref payload 'frames))
+
+  (define-values (imports exports) (imports/exports payload))
+  
+  (define bindings
+    (for/hash ([(frame-id frame-url) frame-urls])
+      (values frame-id (jsexpr->maybe-df (retrieve-frame frame-url)))))
+
+  ;; Evaluate the cell, capturing the result (a hash table containing
+  ;; the exports) and the console output
+  (define-values (result console-output)
+    (let ([ns (make-cell-namespace bindings)]
+          ;; construct the code to evaluate, returning the output frames
+          [code (with-syntax ([body (string->syntax cell-contents)]
+                              [(exports ...) exports])
+                  (strip-context
+                   #'(begin
+                       body
+                       (make-hash (list (cons 'exports exports) ...)))))])
+      
+      (define console (open-output-string))
+      (define/contract result (hash/c symbol? any/c)
+        (parameterize ([current-output-port console])
+          (eval code ns)))
+      (values result (get-output-string console))))
+  
+  ;; Write values to the data store
+  (define output-frame-urls
+    (for/fold ([acc (hash)])
+              ([(k v) result])
+      (define val (maybe-df->jsexpr v))
+      (if (void? val)
+          acc
+          (let ([url-str (datastore-request-url code-hash (symbol->string k))])
+            (unless (store-frame (string->url url-str) val)
+              (raise-user-error
+               (string-append
+                "Error: failed to write a data frame with ~a rows to the "
+                "data-store at ~a")
+               (df-row-count v) url-str))
+            (hash-set acc k url-str)))))
+  
+  (hash 'output console-output
+        'frames output-frame-urls
+        'figures '()))
+
+
+(module+ test
+  (define (check-imports-exports expect-imports expect-exports code-stx)
+    (let* ([code-str (~a (syntax->datum code-stx))]
+           [payload  (hash 'code code-str 'frames '[] 'hash "ignored")]
+           [actual   (exports/jsexpr payload)]
+           [actual-imports (hash-ref actual 'imports)]
+           [actual-exports (hash-ref actual 'exports)])
+      (check-equal? (list->set actual-imports)
+                    (list->set expect-imports))
+      (check-equal? (list->set actual-exports)
+                    (list->set expect-exports))))
+  
+  (test-case "exports"
+    (check-imports-exports '[]    '[]    #'1)
+    (check-imports-exports '[]    '["a"] #'(define a 1))
+    (check-imports-exports '["a"] '["a"] #'a)
+    (check-imports-exports '["c" "w"] '["c" "w" "x" "a" "b"]
+                           #'(begin
+                               (define x (make-data-frame))
+                               (define-values (a b) (values 1 2))
+                               (let ([p 0]
+                                     [c c])
+                                 (define y c) w))))
+
+  (test-case "eval" (void)) ;; TODO: tests of eval (mocking the datastore)
+  )
+
+
+(define (run req)
+  (let ([post-data-json (bytes->jsexpr (request-post-data/raw req))])
+    (match (url->string (request-uri req))
+      ["/exports" (response/json (exports/jsexpr post-data-json))]
+      ["/eval"    (response/json (eval/jsexpr post-data-json))]
+      [_          (response/404)])))
+
+;; entry point: start the server on the indicated port, using the
+;; datastore at datastore-url (: string?)
+(define (start-racket-service [datastore-url (current-datastore)]
+                              #:port [port 7104])
+  (parameterize ([current-datastore datastore-url])
+    (serve/servlet run
+                   #:servlet-regexp #rx""
+                   #:port port
+                   #:launch-browser? #f
+                   #:stateless? #t)))

--- a/server/racket/start-racket-service
+++ b/server/racket/start-racket-service
@@ -1,0 +1,9 @@
+#!/usr/bin/env racket
+#lang racket
+(require "main.rkt")
+(define env (current-environment-variables))
+(define datastore (environment-variables-ref env #"DATASTORE_URI"))
+
+(if datastore
+    (start-racket-service (bytes->string/locale datastore))
+    (start-racket-service))


### PR DESCRIPTION
## Summary
Adds a Racket service (~back-end only~).  See the README for some more details.

## Current limitations:
- ~no attempt at integrating it with the front end~
- ~no Docker yet~
- ~doesn't use CORS~
- no plots/figures
- frames imported by a cell are always re-exported
