### PR TITLE
Bugfix/r comments

### DIFF
--- a/server/R/codeAnalysis.R
+++ b/server/R/codeAnalysis.R
@@ -59,7 +59,7 @@ impexpLeaf <- function(e, w) {
 
 prepCodeString <- function(inputString) {
     ## target of 'quote' needs to be a unique name..
-    codeToParse <- paste("wrattlerParsedCode <- quote({",inputString,"})")
+    codeToParse <- paste("wrattlerParsedCode <- quote({",inputString,"\n })")
     tmpExpression <- parse(text=codeToParse)
     eval(tmpExpression)
     return(wrattlerParsedCode)

--- a/server/R/tests/test_execute.R
+++ b/server/R/tests/test_execute.R
@@ -78,11 +78,20 @@ test_that("We can execute code containing a function with assignments inside", {
     expect_that(result$returnVars[[4]]==14,equals(TRUE))
 })
 
-
+### new version of purrr broke a line of code using 'partial' - test the behavior here
 test_that("The 'partial' function works as expected", {
     hash <- "testhash"
     code <- "library(purrr)\n pmean <- partial(mean, na.rm=TRUE)\n x <- pmean(3,4,5)\n"
     importsList <- c()
     result <- executeCode(code, importsList, hash)
     expect_that(result$returnVars[[2]]==3, equals(TRUE))
+})
+
+## early versions had a problem evaluating cells with a comment on the last line
+test_that("We can evaluate code fragments with comments", {
+    hash <- "testhash"
+    code <- "df <- data.frame(var1=c(1,2,3),var2=c(4,5,6))\n#this is a comment"
+    importsList <- c()
+    result <- executeCode(code, importsList, hash)
+    expect_that(is.data.frame(result$returnVars[[1]]), equals(TRUE))
 })


### PR DESCRIPTION
* When doing the code analysis for R-service, append a newline, to avoid an error when the code fragment ends with a comment.