### PR TITLE
Bugfix/python service dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ server/R/.Rhistory
 *~
 *.ipynb
 resources/.ipynb_checkpoints/
+.cache
+server/python/.cache
+.#*
+#*#

--- a/server/python/python_service.py
+++ b/server/python/python_service.py
@@ -259,6 +259,10 @@ def find_assignments(code_string):
             elif isinstance(node, ast.Call):
                 _find_elements(node.args, output_dict, "input_vals", global_scope)
                 _find_elements(node.func, output_dict, "input_vals", global_scope)
+            ## treat things like df[0] = x (i.e. ast.Subscript nodes) similarly to Call nodes
+            ## - i.e. we will need 'df' to be an import in order to avoid 'not defined' error.
+            elif isinstance(node, ast.Subscript):
+                _find_elements(node.value, output_dict, "input_vals", global_scope)
             elif isinstance(node, ast.Name) and parent:
                 if global_scope or parent=="input_vals":
                     ## only add this name if it isn't already in the list

--- a/server/python/python_service.py
+++ b/server/python/python_service.py
@@ -263,6 +263,8 @@ def find_assignments(code_string):
             ## - i.e. we will need 'df' to be an import in order to avoid 'not defined' error.
             elif isinstance(node, ast.Subscript):
                 _find_elements(node.value, output_dict, "input_vals", global_scope)
+                if parent and parent == "targets":
+                    _find_elements(node.value, output_dict, "targets", global_scope)
             elif isinstance(node, ast.Name) and parent:
                 if global_scope or parent=="input_vals":
                     ## only add this name if it isn't already in the list

--- a/server/python/tests/test_parse_code.py
+++ b/server/python/tests/test_parse_code.py
@@ -109,10 +109,11 @@ def test_method_calling_imports():
     assert(result["exports"] == ["x"])
 
 
-def test_subscript_imports():
+def test_subscript_imports_exports():
     """
     If we look at an element of an object such as a dataframe(e.g. x[0]), that dataframe needs to be
     defined so should be an import.
+    If the element is an assignment target it should also be an export.
     """
     code = "df.x[0] = 3\n"
     frames = ["df"]
@@ -122,6 +123,8 @@ def test_subscript_imports():
     result = handle_exports(testdata)
     assert(len(result["imports"])==1)
     assert(result["imports"][0] == "df")
+    assert(len(result["exports"])==1)
+    assert(result["exports"][0] == "df")
 
 
 

--- a/server/python/tests/test_parse_code.py
+++ b/server/python/tests/test_parse_code.py
@@ -109,6 +109,22 @@ def test_method_calling_imports():
     assert(result["exports"] == ["x"])
 
 
+def test_subscript_imports():
+    """
+    If we look at an element of an object such as a dataframe(e.g. x[0]), that dataframe needs to be
+    defined so should be an import.
+    """
+    code = "df.x[0] = 3\n"
+    frames = ["df"]
+    testdata = {"code": code,
+                "frames": frames,
+                "hash": "irrelevant"}
+    result = handle_exports(testdata)
+    assert(len(result["imports"])==1)
+    assert(result["imports"][0] == "df")
+
+
+
 def test_imports_same_var_twice():
     """
     We only want to read in a dataframe once, even if


### PR DESCRIPTION

Fixes part of #168  where individual values from a dataframe defined in a previous cell were not retrievable as the dataframe wasn't recognized as an import.

With this fix, the ```df``` in the code fragment
```
df.x[0] = 3
```
will be both an import and an export.
