### PR TITLE
Bugfix/r service printout

### DIFF
--- a/server/R/R_service.R
+++ b/server/R/R_service.R
@@ -6,6 +6,11 @@ library(base64enc)
 library(rlang)
 library(arrow)
 
+## arrow will override some possibly useful names from base - fix this here
+array <- base::array
+table <- base::table
+
+
 source("codeAnalysis.R")
 
 if (.Platform$OS.type == "unix") {

--- a/server/R/R_service.R
+++ b/server/R/R_service.R
@@ -161,15 +161,22 @@ writeFrame <- function(frameData, frameName, cellHash) {
     } else if (typeof(frameData)=="closure") {
         return(FALSE) # probably a function definition - we don't want to store this
     } else {
+        wroteOK=FALSE
         # hopefully a dataframe that can be converted into Arrow or JSON
         response <- tryCatch({
             frameRaw <- arrowFromDataFrame(frameData)
-            PUT(url, body=frameRaw, encode="raw")
+            if (!is.null(frameRaw)) {
+                wroteOK=TRUE
+                PUT(url, body=frameRaw, encode="raw")
+            }
         }, error=function(cond) {
             frameJSON <- jsonFromDataFrame(frameData)
-            PUT(url, body=frameJSON, encode="json")
+            if (!is.null(frameJSON)) {
+                wroteOK=TRUE
+                PUT(url, body=frameJSON, encode="json")
+            }
         })
-        return(status_code(response) == 200)
+        if (wroteOK) return(status_code(response) == 200)
     }
     ## If we got to here, didn't manage to put frame on the datastore
     return(FALSE)


### PR DESCRIPTION
* Fixes for #219 
 - prevent arrow from overriding "table"
 - don't try to write to datastore if we get NULL after trying to convert an output into a dataframe