### PR TITLE
Parse files with backticks (fix #240)

### DIFF
--- a/client/src/services/documentService.ts
+++ b/client/src/services/documentService.ts
@@ -32,7 +32,7 @@ async function getDocument(paragraph:string): Promise<DocumentElement[]> {
   }
   
   let documents : DocumentElement[] = []; 
-  var regex = /```[a-z]+[^`]*```/g;
+  var regex = /```[a-z]+((?!```).)*```/g;
   var res; 
   var currentPos = 0;
   


### PR DESCRIPTION
We want to allow one or even two backtics, but not three.

Regex magic copied from here: https://stackoverflow.com/questions/406230/regular-expression-to-match-a-line-that-doesnt-contain-a-word