### PR TITLE
Dependency graph visualization

### DIFF
--- a/client/public/graphviz.md
+++ b/client/public/graphviz.md
@@ -31,7 +31,7 @@ joinRFlip <- rbind(rbind(three,two),one)
 
 ```javascript
 //local fullscreen.js
-makeFullScreen(addOutput, {title: "Hello world!",height:400}, function(id) {
+makeFullScreen({title: "Hello world!",height:400}, function(id) {
   document.getElementById(id).innerHTML = 
     `<img src="https://tomaspweb.blob.core.windows.net/calendar/2015/august-original.jpg" 
        style="height:calc(100% - 40px);max-width:calc(100% - 40px);margin:20px">`;
@@ -43,5 +43,5 @@ makeFullScreen(addOutput, {title: "Hello world!",height:400}, function(id) {
 ```javascript
 //local fullscreen.js
 //local graphviz.js
-createGraphViz(addOutput);
+createGraphViz();
 ```

--- a/client/public/graphviz.md
+++ b/client/public/graphviz.md
@@ -1,0 +1,47 @@
+## Demo
+
+```javascript
+var one = [{'name':'Joe', 'age':50}]
+```
+
+```python
+two = pd.DataFrame({"name":["Jim"], "age":[51]})
+```
+
+```r
+three <- data.frame(name=c("Jane"), age=c(54))
+```
+
+```javascript
+var joinJs = one.concat(two).concat(three)
+var joinJsFlip = three.concat(two).concat(one)
+```
+
+```python
+joinPy = one.append(two).append(three)
+joinPyFlip = three.append(two).append(one)
+```
+
+```r
+joinR <- rbind(rbind(one,two),three)
+joinRFlip <- rbind(rbind(three,two),one)
+```
+
+## Creating full screen dialogs
+
+```javascript
+//local fullscreen.js
+makeFullScreen(addOutput, {title: "Hello world!",height:400}, function(id) {
+  document.getElementById(id).innerHTML = 
+    `<img src="https://tomaspweb.blob.core.windows.net/calendar/2015/august-original.jpg" 
+       style="height:calc(100% - 40px);max-width:calc(100% - 40px);margin:20px">`;
+});
+```
+
+## Graph visualization
+
+```javascript
+//local fullscreen.js
+//local graphviz.js
+createGraphViz(addOutput);
+```

--- a/client/src/definitions/languages.ts
+++ b/client/src/definitions/languages.ts
@@ -125,9 +125,17 @@ interface ScopeDictionary {
  * `EvaluationContext` as an argument. It stores a list of available resources.
 */
 interface EvaluationContext {  
+  /** Provides access to all the language plugins taht are available. */
+  languagePlugins: LanguagePlugins
+
+  /** A list of cells in the current notebook. This can be used to inspect 
+   * aspects of the notebook state, other than the currently evaluated code. */
+  cells: BlockState[]
+
   /** A list of files that were loaded as global or local resources by any 
    * language plugin for any cell appearing before the current one. */
   resources: Resource[]
+
   /** URL for a service that can be used for loading resources using `%global` or `%local`. If you 
    * say `%global test.py`, Wrattler will fetch the file from `<resourceServerUrl>/resources/test.py`. */
   resourceServerUrl: string
@@ -303,12 +311,17 @@ interface BlockState {
   exports: Graph.Node[]
 }
 
+/** A dictionary of language plugins that uses the language name as the key and
+ * returns the concrete instance of a language plugin for each language */
+type LanguagePlugins = { [lang:string] : LanguagePlugin }
+
 export { 
   Block,
   Editor,
   EditorState,
   EditorContext,
   LanguagePlugin,
+  LanguagePlugins,
   BlockState,
   BindingContext,
   BindingResult,

--- a/client/src/languages/markdown.ts
+++ b/client/src/languages/markdown.ts
@@ -148,7 +148,7 @@ class MarkdownBlockKind implements Langs.Block {
     bind: async (context: Langs.BindingContext, block: Langs.Block) : Promise<Langs.BindingResult> => {
       let mdBlock:MarkdownBlockKind = <MarkdownBlockKind> block
       let node:Graph.Node = {
-        language:this.language, 
+        language:"markdown", 
         antecedents:[],
         hash:<string>Md5.hashStr(mdBlock.source),
         value: null,

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -25,11 +25,9 @@ type NotebookEvent =
   NotebookAddEvent | NotebookToggleAddEvent | NotebookRemoveEvent | NotebookUpdateTriggerEvalEvent |
   NotebookBlockEvent | NotebookUpdateEvalStateEvent | NotebookSourceChange | NotebookMoveEvent
 
-type LanguagePlugins = { [lang:string] : Langs.LanguagePlugin }
-
 type NotebookState = {
   contentChanged: (newContent:string) => void,
-  languagePlugins: LanguagePlugins
+  languagePlugins: Langs.LanguagePlugins
   cells: Langs.BlockState[]
   counter: number
   expandedMenu : number
@@ -46,20 +44,20 @@ let paperElementID:string='paper'
 function bindCell (cache:Graph.NodeCache,
   scope:Langs.ScopeDictionary,
   editor:Langs.EditorState,
-  languagePlugins:LanguagePlugins,
+  languagePlugins:Langs.LanguagePlugins,
   resourceServerUrl:string,
   resources:Array<Langs.Resource>): Promise<{code: Graph.Node, exports: Graph.ExportNode[], resources: Array<Langs.Resource>}>{
   let languagePlugin = languagePlugins[editor.block.language]
   return languagePlugin.bind({ resourceServerUrl:resourceServerUrl, cache:cache, scope:scope, resources:resources }, editor.block);
 }
 
-async function bindAllCells(cache:Graph.NodeCache, editors:Langs.EditorState[], languagePlugins:LanguagePlugins, resourceServerUrl:string, stateresources: Array<Langs.Resource>) {
+async function bindAllCells(state:NotebookState, editors:Langs.EditorState[]) {
   var scope : Langs.ScopeDictionary = { };
   var newCells : Langs.BlockState[] = []
   let updatedResources: Array<Langs.Resource> = []
   for (var c = 0; c < editors.length; c++) {
     let editor = editors[c]
-    let {code, exports, resources} = await bindCell(cache, scope, editor, languagePlugins, resourceServerUrl, updatedResources);
+    let {code, exports, resources} = await bindCell(state.cache, scope, editor, state.languagePlugins, state.resourceServerUrl, updatedResources);
     updatedResources = updatedResources.concat(resources)
     var newCell:Langs.BlockState = { editor:editor, code:code, exports:exports, evaluationState: "unevaluated"}
     for (var e = 0; e < exports.length; e++ ) {
@@ -71,7 +69,7 @@ async function bindAllCells(cache:Graph.NodeCache, editors:Langs.EditorState[], 
   return {newCells: newCells, updatedResources: updatedResources};
 }
 
-async function updateAndBindAllCells (state:NotebookState, cell:Langs.BlockState, newSource: string, resourceServerUrl:string): Promise<NotebookState> {
+async function updateAndBindAllCells (state:NotebookState, cell:Langs.BlockState, newSource: string): Promise<NotebookState> {
   Log.trace("binding", "Begin rebinding subsequent cells. Cell: %O, New source: %O", cell, {"newSource": newSource})
   let editors = state.cells.map(c => {
     let lang = state.languagePlugins[c.editor.block.language]
@@ -82,21 +80,23 @@ async function updateAndBindAllCells (state:NotebookState, cell:Langs.BlockState
     }
     else return c.editor;
   });
-  let {newCells, updatedResources} = await bindAllCells(state.cache, editors, state.languagePlugins, resourceServerUrl, state.resources);
+  let {newCells, updatedResources} = await bindAllCells(state, editors);
   return { ...state, cells:newCells, resources:updatedResources };
 }
 
-async function evaluate(node:Graph.Node, languagePlugins:LanguagePlugins, resourceServerUrl:string, resources:Array<Langs.Resource>, triggerEvalStateEvent) {
+async function evaluate(node:Graph.Node, state:NotebookState, 
+    triggerEvalStateEvent:(hash:string,state:"pending"|"done") => void) {
   if (node.value && (Object.keys(node.value).length > 0)) return;
 
   triggerEvalStateEvent(node.hash,"pending")
 
-  for(var ant of node.antecedents) await evaluate(ant, languagePlugins, resourceServerUrl, resources, triggerEvalStateEvent);
+  for(var ant of node.antecedents) await evaluate(ant, state, triggerEvalStateEvent);
 
-  let languagePlugin = languagePlugins[node.language]
+  let languagePlugin = state.languagePlugins[node.language]
   // let source = (<any>node).source ? (<any>node).source.substr(0, 100) + "..." : "(no source)"
   // Log.trace("editor","Evaluating %s node: %s", node.language, source)
-  let evalResult = await languagePlugin.evaluate({resourceServerUrl:resourceServerUrl, resources:resources}, node);
+  let ctx = {resourceServerUrl:state.resourceServerUrl, resources:state.resources, cells:state.cells, languagePlugins:state.languagePlugins}
+  let evalResult = await languagePlugin.evaluate(ctx, node);
   // Log.trace("evaluation","Evaluated %s node. Result: %O", node.language, node.value)
   switch(evalResult.kind) {
     case "success":
@@ -314,7 +314,7 @@ async function update(trigger:(evt:NotebookEvent) => void,
       else 
         newEditors = moveDownEditor(state.cells.map(c => c.editor), evt.cell.editor)
 
-      let {newCells, updatedResources} = await bindAllCells(state.cache, newEditors, state.languagePlugins, state.resourceServerUrl, state.resources)
+      let {newCells, updatedResources} = await bindAllCells(state, newEditors)
       return {...state, cells: newCells, resources: updatedResources};
     }
 
@@ -327,7 +327,7 @@ async function update(trigger:(evt:NotebookEvent) => void,
       let editor = lang.editor.initialize(newId, newBlock);
       let newEditors = spliceEditor(state.cells.map(c => c.editor), editor, evt.id)
       Log.trace('main', "Spliced editor: %O", newEditors)      
-      let {newCells, updatedResources} = await bindAllCells(state.cache, newEditors, state.languagePlugins, state.resourceServerUrl, state.resources)
+      let {newCells, updatedResources} = await bindAllCells(state, newEditors)
       state.resources = state.resources.concat(updatedResources)
       newCells.map(c => {
         Log.trace('main', "New cell: %O", c.editor.block)
@@ -339,11 +339,11 @@ async function update(trigger:(evt:NotebookEvent) => void,
       return {...state, cells: removeCell(state.cells, evt.id) };
 
     case 'evaluate':
-      let triggerEvalStateEvent = (hash, newState) =>
+      let triggerEvalStateEvent = (hash:string, newState:"pending"|"done") =>
         trigger({kind:'evalstate', hash:hash, newState})
       let doEvaluate = async (block:Langs.BlockState) => {
-        await evaluate(block.code, state.languagePlugins, state.resourceServerUrl, state.resources, triggerEvalStateEvent)
-        for(var exp of block.exports) await evaluate(exp, state.languagePlugins, state.resourceServerUrl, state.resources, triggerEvalStateEvent)
+        await evaluate(block.code, state, triggerEvalStateEvent)
+        for(var exp of block.exports) await evaluate(exp, state, triggerEvalStateEvent)
       }
       let blocks = state.cells.filter(b => b.editor.id == evt.id)
       if (blocks.length > 0) doEvaluate(blocks[0]); 
@@ -351,7 +351,7 @@ async function update(trigger:(evt:NotebookEvent) => void,
       return state;
 
     case 'rebind':
-      let newState = await updateAndBindAllCells(state, evt.block, evt.newSource, state.resourceServerUrl);
+      let newState = await updateAndBindAllCells(state, evt.block, evt.newSource);
       state.contentChanged(saveDocument(newState))
       Log.trace('jupyter',"This will trigger a render in Jupyter")
       return newState
@@ -363,7 +363,7 @@ async function update(trigger:(evt:NotebookEvent) => void,
 // ------------------------------------------------------------------------------------------------
 
 async function initializeCells(elementID:string, counter: number, editors:Langs.EditorState[],
-    languagePlugins:LanguagePlugins, resourceServerUrl:string, contentChanged:(newContent:string) => void) {
+    languagePlugins:Langs.LanguagePlugins, resourceServerUrl:string, contentChanged:(newContent:string) => void) {
   let maquetteProjector = createProjector();
   let paperElement = document.getElementById(elementID);
   paperElementID = elementID;
@@ -372,11 +372,10 @@ async function initializeCells(elementID:string, counter: number, editors:Langs.
   if (!paperElement) throw elementNotFoundError
 
   var cache = createNodeCache()
-  var resources:Array<Langs.Resource> = []
-  var {newCells, updatedResources} = await bindAllCells(cache, editors, languagePlugins, resourceServerUrl, resources);
-  resources = updatedResources
-  var state : NotebookState = {cache:cache, counter:counter, cells:newCells, resourceServerUrl:resourceServerUrl,
-    contentChanged: contentChanged, expandedMenu:-1, languagePlugins:languagePlugins, resources: resources}
+  var prestate : NotebookState = {cache:cache, counter:counter, cells:[], resourceServerUrl:resourceServerUrl,
+    contentChanged: contentChanged, expandedMenu:-1, languagePlugins:languagePlugins, resources: []}
+  var {newCells, updatedResources} = await bindAllCells(prestate, editors);
+  var state : NotebookState = {...prestate, cells:newCells, resources: updatedResources}
 
   var events : NotebookEvent[] = []
   var handling = false;
@@ -407,7 +406,7 @@ async function initializeCells(elementID:string, counter: number, editors:Langs.
   maquetteProjector.replace(paperElement, () => render(trigger, state))
 }
 
-function loadNotebook(documents:Docs.DocumentElement[], languagePlugins:LanguagePlugins) {
+function loadNotebook(documents:Docs.DocumentElement[], languagePlugins:Langs.LanguagePlugins) {
   let index = 0
   let blockStates = documents.map(cell => {
     let languagePlugin = languagePlugins[cell.language]; // TODO: Error handling
@@ -442,7 +441,6 @@ function createNodeCache() : Graph.NodeCache {
 }
 
 export {
-  LanguagePlugins, 
   loadNotebook, 
   initializeCells
 }

--- a/resources/fullscreen.js
+++ b/resources/fullscreen.js
@@ -1,0 +1,35 @@
+function createDialog(id, title, f) {
+  if (!document.getElementById(id)) {
+    var dialog = document.createElement("div");
+    dialog.id = id;
+    dialog.innerHTML = 
+      `<div style="background:white;border:solid 5px #d0d0d0;
+          position:fixed;width:80vw;height:90vh;left:10vw;top:5vh">
+        <div style="color:#c0c0c0;padding:0px 10px 0px 10px">
+          <a href="javascript:;" style="color:#c0c0c0; text-decoration:none; font-weight:bold; float:right" id="${ id }-close">x</a>
+          <strong>${ title }</strong></div>
+        <div id="${ id }-body" style="height:calc(90vh - 35px)"></div>
+       </div>`;
+    document.body.appendChild(dialog);
+    document.getElementById(id + "-close").onclick = function() {
+      document.body.removeChild(document.getElementById(id));
+    }
+    f(id + "-body");
+  }
+}
+
+function makeFullScreen(addOutput, options, f) {
+  let key = options.key ? options.key : "dialog"
+  let title = options.title ? options.title : "Full screen view"
+  let style = options.height ? "height:" + options.height + "px" : ""
+  addOutput(function (id) {
+    document.getElementById(id).innerHTML = 
+      `<a id='${ id }-link' href='javascript:;' style='color:#c0c0c0; 
+        text-decoration:none; font:bold 10pt Roboto; float:right'>full screen</a>
+        <div id='${ id }-small' style='${ style }'></div>`
+    document.getElementById(id + "-link").onclick = function () {
+      createDialog(key, title, f);
+    }
+    f(id + "-small")
+  });
+}

--- a/resources/fullscreen.js
+++ b/resources/fullscreen.js
@@ -18,7 +18,7 @@ function createDialog(id, title, f) {
   }
 }
 
-function makeFullScreen(addOutput, options, f) {
+function makeFullScreen(options, f) {
   let key = options.key ? options.key : "dialog"
   let title = options.title ? options.title : "Full screen view"
   let style = options.height ? "height:" + options.height + "px" : ""

--- a/resources/graphviz.js
+++ b/resources/graphviz.js
@@ -1,0 +1,63 @@
+var colors = [ "#8DD3C7", "#BEBADA", "#FDB462", "#B3DE69", "#FB8072" ]
+
+function createGraphVizBody(id) {
+  var container = document.getElementById(id);  
+
+  var nodes = []
+  var edges = []
+  var added = {}
+
+  function walkNode(node, parentId, lvl) {
+    if (parentId != null)
+      edges.push({"from":parentId, "to":node.hash,
+       arrows: { "to": { enabled: true, type: "triangle" } } });
+
+    if (added[node.hash]) return;
+    added[node.hash] = true;
+    
+    let lbl = node.hash;
+    if (node.kind) lbl = node.language + " " + node.kind; 
+    else if (node.kind == "export") lbl = "export " + node.variableName;
+    else if (node.language == "markdown") lbl = "markdown";
+
+    let clr = colors[Object.keys(context.languagePlugins).indexOf(node.language) % 5];
+
+    let gn = {"id":node.hash, "label":lbl, "color":clr, "level":lvl }
+    if (node.kind == "code" || node.language == "markdown") { 
+      gn.physics = false;
+      gn.x = 100;
+      gn.y = lvl * 100;
+    }
+    nodes.push(gn);
+    for(var a of node.antecedents) walkNode(a, node.hash, lvl);
+  }
+
+  let allNodes = context.cells.map(c => c.exports.concat(c.code))
+  for(let i = 0; i < allNodes.length; i++) {
+    for(let n of allNodes[i]) walkNode(n, null, i);
+  }
+
+  var visNodes = new vis.DataSet(nodes);
+  var visEdges = new vis.DataSet(edges);
+  var data = { nodes: visNodes, edges: visEdges };
+  var options = { physics: {enabled: true, solver: "repulsion" } };
+  var network = new vis.Network(container, data, options);
+}
+
+function createGraphViz(addOutput) {
+  var found = false;
+  var url = "https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis-network.min.js";
+  for(let c of document.head.children) if (c.src == url) { found=true; break; }
+  if (!found) {
+    var scr = document.createElement("script");
+    scr.setAttribute("src", url);
+    document.head.appendChild(scr);
+  }
+  makeFullScreen(addOutput, {key:"graphviz", title:"Wrattler dependency graph", height:600}, function(id) {
+    function check() { 
+      if (typeof(vis) != "undefined") createGraphVizBody(id)
+      else window.setTimeout(check, 100);
+    }
+    window.setTimeout(check, 100);  
+  });
+};

--- a/resources/graphviz.js
+++ b/resources/graphviz.js
@@ -44,7 +44,7 @@ function createGraphVizBody(id) {
   var network = new vis.Network(container, data, options);
 }
 
-function createGraphViz(addOutput) {
+function createGraphViz() {
   var found = false;
   var url = "https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis-network.min.js";
   for(let c of document.head.children) if (c.src == url) { found=true; break; }
@@ -53,7 +53,7 @@ function createGraphViz(addOutput) {
     scr.setAttribute("src", url);
     document.head.appendChild(scr);
   }
-  makeFullScreen(addOutput, {key:"graphviz", title:"Wrattler dependency graph", height:600}, function(id) {
+  makeFullScreen({key:"graphviz", title:"Wrattler dependency graph", height:600}, function(id) {
     function check() { 
       if (typeof(vis) != "undefined") createGraphVizBody(id)
       else window.setTimeout(check, 100);


### PR DESCRIPTION
This is adding a (fairly simple, but demoable) visualization of Wrattler dependency graph:

<img width="815" alt="graph" src="https://user-images.githubusercontent.com/485413/69382746-c0b32f00-0caf-11ea-8520-eb2cac5de7a3.png">

This is actually done with only very small modification of Wrattler. I added a hidden parameter `context` that JavaScript code cells in Wrattler can use to access some information about the notebook (most importantly, the dependency graph). This is the change in `typescript.ts`.

Once this information is available, you can actually build a dependency graph visualizer as a normal JavaScript file that's loaded using our `//local graphviz.js` and then you can invoke it from JavaScript cell:

```
//local fullscreen.js
//local graphviz.js
createGraphViz();
```

As a bonus, I also wrote some code that lets you add "full screen" button to your JS outputs to make them full screen. We can try using this with @annahadji for her maps!

@myyong @nbarlowATI Sorry, this is another change (albeit quite small) to Wrattler core, so I'm afraid it will require a new release.