### PR TITLE
Bugfix/python service binder files

### DIFF
--- a/server/R/R_service.R
+++ b/server/R/R_service.R
@@ -92,13 +92,17 @@ getNameAndHashFromURL <- function(url) {
 
 getFileContent <- function(url) {
     ## retrieve contents of a file (e.g. containing function definitions) from the datastore
-    r <- tryCatch({ GET(url, add_headers(Accept="text/html")) },
-       error=function(cond) {
-           filenameAndHash <- getNameAndHashFromURL(url)
-           return(GET(makeURL(filenameAndHash[[1]], filenameAndHash[[2]]),
-                      add_headers(Accept="text/html")))
-       }
-    )
+    r <- tryCatch({
+        ## first try to construct the URL ourselves based on
+        ## the hash, filename, and our datastore URL
+        filenameAndHash <- getNameAndHashFromURL(url)
+        return(GET(makeURL(filenameAndHash[[1]], filenameAndHash[[2]]),
+                   add_headers(Accept="text/html")))
+    }, error=function(cond) {
+            ## try falling back on the URL we were given
+            GET(url, add_headers(Accept="text/html")) },
+    })
+
     if ( r$status != 200) {
         print("Unable to access datastore")
         return(NULL)

--- a/server/R/R_service.R
+++ b/server/R/R_service.R
@@ -100,7 +100,7 @@ getFileContent <- function(url) {
                    add_headers(Accept="text/html")))
     }, error=function(cond) {
             ## try falling back on the URL we were given
-            GET(url, add_headers(Accept="text/html")) },
+            GET(url, add_headers(Accept="text/html"))
     })
 
     if ( r$status != 200) {

--- a/server/python/setup.py
+++ b/server/python/setup.py
@@ -15,7 +15,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="wrattler-python-service",
-    version="0.5.3",
+    version="0.6",
     description="Python language service for the Wrattler notebook project",
     url="https://github.com/wrattler/wrattler",
     author="Nick Barlow, Tomas Petricek, May Yong",

--- a/server/python/wrattler_python_service/python_service_utils.py
+++ b/server/python/wrattler_python_service/python_service_utils.py
@@ -48,16 +48,16 @@ def get_file_content(url):
     (likely some function definitions and/or import statements).
     """
     try:
-        r=requests.get(url)
+        cell_hash, file_name = url.split("/")[-2:]
+        ds_url = '{}/{}/{}'.format(DATASTORE_URI, cell_hash, file_name)
+        r=requests.get(ds_url)
         if r.status_code is not 200:
             raise ApiException("Could not retrieve dataframe", status_code=r.status_code)
         file_content = r.content.decode("utf-8")
         return file_content
     except(requests.exceptions.ConnectionError):
         try:
-            ## Try falling back on the datastore environment variable
-            cell_hash, file_name = url.split("/")[-2:]
-            url = '{}/{}/{}'.format(DATASTORE_URI, cell_hash, file_name)
+            ## Try falling back on the URL we were given
             r = requests.get(url)
             if r.status_code is not 200:
                 raise ApiException("Could not retrieve dataframe", status_code=r.status_code)


### PR DESCRIPTION
To load e.g. function definition from files using the `%local` or `%global` magics, both the python and R services originally tried first to get the file contents from the datastore via the URL passed by the client, and if this didn't work, construct the URL themselves based on their idea of where the datastore is, plus the hash and filename.
This works fine for local running, where if we can't access the first-try URL we get a 404.  However, when running in Binder, we try to go via the proxy, and get a page of HTML, but a 200 status code.

To fix this, reverse the order in which we try the URLs - first construct our own using the hash and filename, and then if that doesn't work try the one in the HTTP request from the client.