### PR TITLE
Fix styling of JupyterLab hosted notebooks

### DIFF
--- a/client/public/index.css
+++ b/client/public/index.css
@@ -23,9 +23,8 @@ div.cell {
 }
 div.icons-bar {
 	height:25px;
-	margin-top:10px;
 	overflow:hidden;
-	margin-left:-15px;
+	margin:10px -15px 0px -15px;
 }
 div.content-bar {
 	padding:10px 0px 10px 0px;
@@ -47,6 +46,10 @@ div.controls {
 .controls-bar a, .icons-bar span {
 	font-size:10pt;
 	font-weight:bold;
+}
+.move a {
+	cursor: pointer;
+	margin-left:2px;
 }
 .controls-bar a {
 	margin:0px 0px 0px 15px;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -159,16 +159,10 @@ function render(trigger:(evt:NotebookEvent) => void, state:NotebookState) {
     ])
 
     let move = h('div', {class:'move'}, [
-      h('i', {
-        id:'moveUp_'+cell.editor.id, 
-        class: 'fa fa-arrow-up', 
-        onclick:()=>{trigger({ kind:'move', cell: cell, direction:"up" })}
-      }, []),
-      h('i', {
-        id:'moveDown_'+cell.editor.id, 
-        class: 'fa fa-arrow-down',
-        onclick:()=>{trigger({ kind:'move', cell: cell, direction:"down"})}
-      }, []),
+      h('a', { onclick:()=> trigger({ kind:'move', cell: cell, direction:"up" }) },
+        [ h('i', { class: 'fa fa-arrow-up' }) ]),
+      h('a', { onclick:()=> trigger({ kind:'move', cell: cell, direction:"down" }) },
+        [ h('i', { class: 'fa fa-arrow-down' }) ])
     ])
 
     let langs = Object.keys(state.languagePlugins).map(lang =>

--- a/jupyterlab_wrattler/package.json
+++ b/jupyterlab_wrattler/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/my_name/myextension.git"
   },
   "scripts": {
-    "build": "echo /* DO NOT EDIT! AUTOMATICALLY COPIED FROM client/public/index.css */ | cat - ../client/public/index.css > style/index.css && tsc",
+    "build": "tsc",
     "clean": "rimraf lib",
     "prepare": "npm run clean && npm run build",
     "watch": "tsc -w"

--- a/jupyterlab_wrattler/package.json
+++ b/jupyterlab_wrattler/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/my_name/myextension.git"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "echo /* DO NOT EDIT! AUTOMATICALLY COPIED FROM client/public/index.css */ | cat - ../client/public/index.css > style/index.css && tsc",
     "clean": "rimraf lib",
     "prepare": "npm run clean && npm run build",
     "watch": "tsc -w"

--- a/jupyterlab_wrattler/src/index.ts
+++ b/jupyterlab_wrattler/src/index.ts
@@ -1,5 +1,6 @@
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { Widget } from '@phosphor/widgets';
+import '../style/jupyter.css';
 import '../style/index.css';
 
 

--- a/jupyterlab_wrattler/style/index.css
+++ b/jupyterlab_wrattler/style/index.css
@@ -1,14 +1,13 @@
+/* DO NOT EDIT! AUTOMATICALLY COPIED FROM client/public/index.css */ 
 @import url('https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono');
 
 /* ----------------------------------------------------------------------------
 	General notebook and cells styles	
 -----------------------------------------------------------------------------*/
-.jp-Wrattler {
-	overflow: scroll;
-}
 
 body { 
 	font-family:Roboto;
+	background:#f0f0f0;
 }
 #paper {
 	margin:0px auto 800px auto;
@@ -25,9 +24,8 @@ div.cell {
 }
 div.icons-bar {
 	height:25px;
-	margin-top:10px;
 	overflow:hidden;
-	margin-left:-15px;
+	margin:10px -15px 0px -15px;
 }
 div.content-bar {
 	padding:10px 0px 10px 0px;
@@ -40,12 +38,19 @@ div.controls-bar {
 div.icons {
 	float:left;
 }
+div.move {
+	float:right;
+}
 div.controls {
 	float:right;
 }
 .controls-bar a, .icons-bar span {
 	font-size:10pt;
 	font-weight:bold;
+}
+.move a {
+	cursor: pointer;
+	margin-left:2px;
 }
 .controls-bar a {
 	margin:0px 0px 0px 15px;
@@ -58,6 +63,11 @@ div.controls {
 	font-size:10pt;
 	margin-right:5px;
 }
+
+.cell-c-default .controls-bar a, .cell-c-default .icons-bar span, .cell-c-default .controls-bar .fa, 
+	.cell-c-default .icons-bar .fa, .cell-c-default .controls-bar .fab, .cell-c-default .icons-bar .fab { color:#d0d0d0; }
+.cell-c-default { border-color:#d0d0d0; }
+.cell-c-default a:hover, .cell-c-default a:hover i { color:#a0a0a0 !important; }
 
 .cell-c0 .controls-bar a, .cell-c0 .icons-bar span, .cell-c0 .controls-bar .fa, 
 	.cell-c0 .icons-bar .fa, .cell-c0 .controls-bar .fab, .cell-c0 .icons-bar .fab { color:#8DD3C7; }
@@ -250,3 +260,156 @@ button.delete {
  }
 
 
+/* ----------------------------------------------------------------------------
+	AI assistants
+-----------------------------------------------------------------------------*/
+
+.aia li {
+	margin-bottom:10px;
+}
+.aia div.body {
+	padding-left:30px;
+}
+.aia div.body > span:first-child {
+	margin-left:-30px;
+}
+.aia input {
+	border:solid 3px #e8e8e8;
+	background:#fafafa;
+	padding:2px 10px 3px 10px;
+	color:#808080;
+	font-size: 11pt;
+	letter-spacing:0.5px;
+	font-weight: bold;
+	width:120px;
+}
+.aia .text {
+	margin:0px 10px 0px 5px;
+}
+.aia .chain, .aia .plus button { 
+	background:#f4f4f4; 
+	border:solid 3px #e8e8e8;
+	padding:2px 6px 2px 6px;
+	margin:0px 8px 8px 0px;
+	border-radius:4px; 
+	display:inline-block;
+	cursor:default;
+	color:#808080;
+	font-size: 11pt;
+	letter-spacing:0.5px;
+	font-weight: bold;
+}
+.aia .preview {
+	margin-top:10px;
+}
+.aia .plus {
+	min-height:32px;
+	margin:0px 8px 4px 0px;
+	display:inline-block;
+}
+.aia .chain button {
+	border-style:none;
+	background:inherit;
+	color:#808080;
+	font-size:80%;
+	margin:0px 0px 0px 2px;
+	padding:2px 4px 2px 4px;
+	cursor:pointer;
+}
+.aia .plus button {
+	background:#808080;
+	border-style:none;
+	color:white;
+	font-size:60%;
+	position:relative;
+	top:0px;
+	margin-right:0px;
+	cursor:pointer;
+}
+.aia ::placeholder {
+  color:#d0d0d0;
+  opacity: 1;
+}
+
+.aia .completion {
+	width:200px;
+	max-height:300px;
+	overflow-y:auto;
+	overflow-x:auto;
+	vertical-align:top;
+	background:#f4f4f4; 
+	border:solid 3px #e8e8e8;
+	padding:0px;
+	margin:4px 8px 4px 0px;
+	border-radius:4px; 
+	display:inline-block;
+	color:#808080;
+	font-size: 11pt;
+	letter-spacing:0.5px;
+}
+.aia .completion .item {
+	display:block;
+	cursor:pointer;	
+	white-space: nowrap;
+	padding:0px 10px 0px 6px;
+}
+.aia .completion a:hover {
+	background:#e8e8e8;
+	color:#606060 !important;
+}
+
+.aia .tools {
+	padding:5px 0px 5px 0px;
+}
+.aia .tools div {
+	margin:5px 10px 0px 0px;
+}
+.aia .tools div span {
+	min-width:80px;
+	margin-top:2px;
+	float:left;
+}
+.aia .tools select {
+	border:solid 3px #e8e8e8;
+	background:#f4f4f4;
+	padding:2px 10px 2px 10px;
+	color:#808080;
+	font-size: 11pt;
+	letter-spacing:0.5px;
+}
+.aia .tools button {
+	border:solid 3px #e8e8e8;
+	background:#f4f4f4;
+	padding:1px 10px 0.5px 10px;
+	color:#808080;
+	font-size: 11pt;
+	letter-spacing:0.5px;
+	font-weight: bold;
+	margin:5px 0px 0px 0px;
+}
+.aia .tools button:disabled {
+	color:#d0d0d0;
+}
+
+/* ----------------------------------------------------------------------------
+	Spreadsheet plugin
+-----------------------------------------------------------------------------*/
+.spreadsheet-table { 
+	border-spacing: 0px; 
+	border-bottom:1px solid #e0e0e0; 
+	border-right:1px solid #e0e0e0; 
+}
+.spreadsheet-td, .spreadsheet-th { 
+	width:50px; 
+	border-left:1px solid #e0e0e0; 
+	border-top:1px solid #e0e0e0; 
+	border-bottom:1px solid #e0e0e0; 
+	padding:5px; 
+}    
+.spreadsheet-td.selected { 
+	padding:0px; 
+}
+.spreadsheet-td input { 
+	width:56px; 
+	height:22px; 
+}

--- a/jupyterlab_wrattler/style/index.css
+++ b/jupyterlab_wrattler/style/index.css
@@ -1,4 +1,3 @@
-/* DO NOT EDIT! AUTOMATICALLY COPIED FROM client/public/index.css */ 
 @import url('https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono');
 
 /* ----------------------------------------------------------------------------

--- a/jupyterlab_wrattler/style/jupyter.css
+++ b/jupyterlab_wrattler/style/jupyter.css
@@ -1,0 +1,9 @@
+.jp-Wrattler {
+  overflow: auto;
+  line-height: 1.5;
+  font-family: 'roboto';
+}
+
+.jp-Wrattler div.cell {
+  width:auto;
+}


### PR DESCRIPTION
This should fix the CSS for Wrattler (so that the notebook does not overflow).

Note that I tweaked the build to copy `index.css` from `client/public` and added `jupyter.css` which contains Jupyter-specfic styles (so that we don't have to copy all changes manually).